### PR TITLE
Feat: Add API Cheatsheets for JS and Python

### DIFF
--- a/data/cheatsheets/chart-api-en.json
+++ b/data/cheatsheets/chart-api-en.json
@@ -1,0 +1,34 @@
+{
+  "title": "Chart API",
+  "language": "en",
+  "tags": ["charts", "javascript", "api"],
+  "items": [
+    {
+      "code": "new frappe.ui.RealtimeChart(dom_element, event_name, max_label_count, data)",
+      "description": "Creates a new RealtimeChart instance that adds real-time data update functionality on top of the Frappe Chart API.",
+      "example": "const data = {\n datasets: [\n {\n name: \"Some Data\",\n values: [],\n },\n ],\n};\n\nlet chart = new frappe.ui.RealtimeChart(\"#chart\", \"test_event\", 8, {\n title: \"My Realtime Chart\",\n data: data,\n type: \"line\",\n height: 250,\n colors: [\"#7cd6fd\", \"#743ee2\"]\n});"
+    },
+    {
+      "code": "frappe.publish_realtime(event, data)",
+      "description": "This Python code can be executed to publish real-time data for the chart. The 'label' key specifies the label to be appended, and 'points' specifies the data points.",
+      "example": "data = {\n 'label': 1,\n 'points': [10]\n}\nfrappe.publish_realtime('test_event', data)"
+    },
+    {
+      "code": "chart.start_updating()",
+      "description": "Start listening to the specified socket event and update the RealtimeChart accordingly.",
+      "example": "chart.start_updating();"
+    },
+    {
+      "code": "chart.stop_updating()",
+      "description": "Stop listening to the socket event that RealtimeChart was initialized with.",
+      "example": "chart.stop_updating();"
+    },
+    {
+      "code": "chart.update_chart(label, data)",
+      "description": "Manually updates RealtimeChart by appending the label and associated data to the end of the chart.",
+      "example": "chart.update_chart(2, [30]);"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/chart-api.json
+++ b/data/cheatsheets/chart-api.json
@@ -1,0 +1,34 @@
+{
+  "title": "API de Gráficos",
+  "language": "es",
+  "tags": ["gráficos", "javascript", "api"],
+  "items": [
+    {
+      "code": "new frappe.ui.RealtimeChart(dom_element, event_name, max_label_count, data)",
+      "description": "Crea una nueva instancia de RealtimeChart que agrega funcionalidad de actualización de datos en tiempo real sobre la API de Frappe Charts.",
+      "example": "const data = {\n datasets: [\n {\n name: \"Algunos Datos\",\n values: [],\n },\n ],\n};\n\nlet chart = new frappe.ui.RealtimeChart(\"#chart\", \"test_event\", 8, {\n title: \"Mi Gráfico en Tiempo Real\",\n data: data,\n type: \"line\",\n height: 250,\n colors: [\"#7cd6fd\", \"#743ee2\"]\n});"
+    },
+    {
+      "code": "frappe.publish_realtime(event, data)",
+      "description": "Este código de Python se puede ejecutar para publicar datos en tiempo real para el gráfico. La clave 'label' especifica la etiqueta que se agregará y 'points' especifica los puntos de datos.",
+      "example": "data = {\n 'label': 1,\n 'points': [10]\n}\nfrappe.publish_realtime('test_event', data)"
+    },
+    {
+      "code": "chart.start_updating()",
+      "description": "Comienza a escuchar el evento de socket especificado y actualiza el RealtimeChart en consecuencia.",
+      "example": "chart.start_updating();"
+    },
+    {
+      "code": "chart.stop_updating()",
+      "description": "Deja de escuchar el evento de socket con el que se inicializó RealtimeChart.",
+      "example": "chart.stop_updating();"
+    },
+    {
+      "code": "chart.update_chart(label, data)",
+      "description": "Actualiza manualmente RealtimeChart agregando la etiqueta y los datos asociados al final del gráfico.",
+      "example": "chart.update_chart(2, [30]);"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/common-utilities-en.json
+++ b/data/cheatsheets/common-utilities-en.json
@@ -1,0 +1,34 @@
+{
+  "title": "Common Utilities API",
+  "language": "en",
+  "tags": ["utilities", "javascript", "api"],
+  "items": [
+    {
+      "code": "frappe.get_route()",
+      "description": "Returns the current route as an array.",
+      "example": "frappe.get_route()\n// returns [\"List\", \"Task\", \"List\"]"
+    },
+    {
+      "code": "frappe.set_route(route)",
+      "description": "Changes the current route to the provided route.",
+      "example": "// route in parts\nfrappe.set_route('List', 'Task', 'List')\n\n// route as array\nfrappe.set_route(['List', 'Task', 'Gantt'])\n\n// route as string\nfrappe.set_route('List/Event/Calendar')\n\n// route with options\nfrappe.set_route(['List', 'Task', 'Task'], { status: 'Open' })"
+    },
+    {
+      "code": "frappe.format(value, df, options, doc)",
+      "description": "Formats a raw value into a user-presentable format.",
+      "example": "frappe.format('2019-09-08', { fieldtype: 'Date' })\n// \"09-08-2019\"\n\nfrappe.format('2399', { fieldtype: 'Currency', options: 'currency' }, { inline: true })\n// \"2,399.00\""
+    },
+    {
+      "code": "frappe.provide(namespace)",
+      "description": "Creates a namespace attached to the window object if it doesn't exist.",
+      "example": "frappe.provide('frappe.ui.form');\n\n// has the same effect as\nwindow.frappe = {}\nwindow.frappe.ui = {}\nwindow.frappe.ui.form = {}"
+    },
+    {
+      "code": "frappe.require(asset_path, callback)",
+      "description": "Loads a JS or CSS asset asynchronously.",
+      "example": "// load a single asset\nfrappe.require('/assets/frappe/chat.js', () => {\n // chat.js is loaded\n})\n\n// load multiple assets\nfrappe.require(['/assets/frappe/chat.js', '/assets/frappe/chat.css'], () => {\n // chat.js and chat.css are loaded\n})"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/common-utilities.json
+++ b/data/cheatsheets/common-utilities.json
@@ -1,0 +1,34 @@
+{
+  "title": "API de Utilidades Comunes",
+  "language": "es",
+  "tags": ["utilidades", "javascript", "api"],
+  "items": [
+    {
+      "code": "frappe.get_route()",
+      "description": "Devuelve la ruta actual como un array.",
+      "example": "frappe.get_route()\n// devuelve [\"List\", \"Task\", \"List\"]"
+    },
+    {
+      "code": "frappe.set_route(route)",
+      "description": "Cambia la ruta actual a la ruta proporcionada.",
+      "example": "// ruta en partes\nfrappe.set_route('List', 'Task', 'List')\n\n// ruta como array\nfrappe.set_route(['List', 'Task', 'Gantt'])\n\n// ruta como string\nfrappe.set_route('List/Event/Calendar')\n\n// ruta con opciones\nfrappe.set_route(['List', 'Task', 'Task'], { status: 'Open' })"
+    },
+    {
+      "code": "frappe.format(value, df, options, doc)",
+      "description": "Formatea un valor crudo a un formato presentable para el usuario.",
+      "example": "frappe.format('2019-09-08', { fieldtype: 'Date' })\n// \"09-08-2019\"\n\nfrappe.format('2399', { fieldtype: 'Currency', options: 'currency' }, { inline: true })\n// \"2,399.00\""
+    },
+    {
+      "code": "frappe.provide(namespace)",
+      "description": "Crea un espacio de nombres adjunto al objeto window si no existe.",
+      "example": "frappe.provide('frappe.ui.form');\n\n// tiene el mismo efecto que\nwindow.frappe = {}\nwindow.frappe.ui = {}\nwindow.frappe.ui.form = {}"
+    },
+    {
+      "code": "frappe.require(asset_path, callback)",
+      "description": "Carga un recurso JS o CSS de forma asíncrona.",
+      "example": "// cargar un solo recurso\nfrappe.require('/assets/frappe/chat.js', () => {\n // chat.js está cargado\n})\n\n// cargar múltiples recursos\nfrappe.require(['/assets/frappe/chat.js', '/assets/frappe/chat.css'], () => {\n // chat.js y chat.css están cargados\n})"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/controls-en.json
+++ b/data/cheatsheets/controls-en.json
@@ -1,0 +1,164 @@
+{
+  "title": "Controls",
+  "language": "en",
+  "tags": ["javascript", "ui", "controls"],
+  "items": [
+    {
+      "code": "frappe.ui.form.make_control({ parent, df })",
+      "description": "Makes a frappe control based on df properties and appends it into the parent container.",
+      "example": "frappe.ui.form.make_control({\n parent: $wrapper.find('.my-control'),\n df: {\n label: 'Due Date',\n fieldname: 'due_date',\n fieldtype: 'Date'\n },\n render_input: true\n})"
+    },
+    {
+      "code": "{ fieldtype: 'Attach' }",
+      "description": "Attach control to upload files.",
+      "example": "{\n label: 'Attachment',\n fieldname: 'attachment',\n fieldtype: 'Attach'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Attach Image' }",
+      "description": "Attach Image control to upload images.",
+      "example": "{\n label: 'User Image',\n fieldname: 'user_image',\n fieldtype: 'Attach Image'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Autocomplete' }",
+      "description": "Autocomplete control for selecting from a list of options.",
+      "example": "{\n label: 'Select User',\n fieldname: 'user',\n fieldtype: 'Autocomplete',\n options: [\n 'faris@erpnext.com',\n 'suraj@erpnext.com'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Barcode' }",
+      "description": "Barcode control.",
+      "example": "{\n label: 'Item Barcode',\n fieldname: 'item_barcode',\n fieldtype: 'Barcode'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Check' }",
+      "description": "Checkbox control.",
+      "example": "{\n label: 'Enable feature',\n fieldname: 'enable_feature',\n fieldtype: 'Check'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Code' }",
+      "description": "Code editor control with syntax highlighting.",
+      "example": "{\n label: 'JS Script',\n fieldname: 'script',\n fieldtype: 'Code',\n options: 'Javascript',\n wrap: true,\n max_lines: 10,\n min_lines: 5\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Color' }",
+      "description": "Color picker control.",
+      "example": "{\n label: 'Your favorite color',\n fieldname: 'user_color',\n fieldtype: 'Color'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Currency' }",
+      "description": "Currency input control.",
+      "example": "{\n label: 'Amount',\n fieldname: 'amount',\n fieldtype: 'Currency',\n options: 'INR'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Data' }",
+      "description": "Generic data input control.",
+      "example": "{\n label: 'First Name',\n fieldname: 'first_name',\n fieldtype: 'Data',\n options: 'Email'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Date Range' }",
+      "description": "Date range picker control.",
+      "example": "{\n label: 'Select Date Range',\n fieldname: 'date_range',\n fieldtype: 'Date Range'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Date' }",
+      "description": "Date picker control.",
+      "example": "{\n label: 'Birth Date',\n fieldname: 'birth_date',\n fieldtype: 'Date'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Datetime' }",
+      "description": "Datetime picker control.",
+      "example": "{\n label: 'Submission Date and Time',\n fieldname: 'submission',\n fieldtype: 'Datetime'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Dynamic Link' }",
+      "description": "Dynamic link control that links to different DocTypes.",
+      "example": "{\n label: 'Party',\n fieldname: 'party',\n fieldtype: 'Dynamic Link',\n options: 'party_type'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Float' }",
+      "description": "Float input control.",
+      "example": "{\n label: 'Threshold',\n fieldname: 'threshold',\n fieldtype: 'Float'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Geolocation' }",
+      "description": "Geolocation control.",
+      "example": "{\n label: 'Meeting Place',\n fieldname: 'meeting_place',\n fieldtype: 'Geolocation'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'HTML Editor' }",
+      "description": "HTML editor control.",
+      "example": "{\n label: 'Custom HTML',\n fieldname: 'custom_html',\n fieldtype: 'HTML Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Int' }",
+      "description": "Integer input control.",
+      "example": "{\n label: 'No of days',\n fieldname: 'no_of_days',\n fieldtype: 'Int'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Link' }",
+      "description": "Link control to another DocType.",
+      "example": "{\n label: 'Select User',\n fieldname: 'user',\n fieldtype: 'Link',\n options: 'User'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Markdown Editor' }",
+      "description": "Markdown editor control.",
+      "example": "{\n label: 'Blog Content',\n fieldname: 'content',\n fieldtype: 'Markdown Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'MultiCheck' }",
+      "description": "Multiple checkbox control.",
+      "example": "{\n label: 'Blog Content',\n fieldname: 'content',\n fieldtype: 'MultiCheck',\n options: [\n 'Option 1',\n 'Option 2',\n 'Option 3',\n 'Option 4',\n ],\n columns: 2\n}"
+    },
+    {
+      "code": "{ fieldtype: 'MultiSelect' }",
+      "description": "Multi-select dropdown control.",
+      "example": "{\n label: 'Select Users',\n fieldname: 'users',\n fieldtype: 'MultiSelect',\n options: [\n 'faris@erpnext.com',\n 'suraj@erpnext.com',\n 'shivam@erpnext.com'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Password' }",
+      "description": "Password input control.",
+      "example": "{\n label: 'New Password',\n fieldname: 'password',\n fieldtype: 'Password'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Rating' }",
+      "description": "Rating control.",
+      "example": "{\n label: 'Rate your experience',\n fieldname: 'rating',\n fieldtype: 'Rating'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Select' }",
+      "description": "Select dropdown control.",
+      "example": "{\n label: 'Status',\n fieldname: 'status',\n fieldtype: 'Select',\n options: [\n 'Open',\n 'Closed',\n 'Cancelled'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Signature' }",
+      "description": "Signature pad control.",
+      "example": "{\n label: 'Status',\n fieldname: 'status',\n fieldtype: 'Signature'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Text Editor' }",
+      "description": "Rich text editor control.",
+      "example": "{\n label: 'Description',\n fieldname: 'description',\n fieldtype: 'Text Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Time' }",
+      "description": "Time picker control.",
+      "example": "{\n label: 'In Time',\n fieldname: 'in_time',\n fieldtype: 'Time'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Button' }",
+      "description": "Button control.",
+      "example": "{\n label: 'Fetch',\n fieldname: 'fetch',\n fieldtype: 'Button',\n btn_size: 'xs'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Icon' }",
+      "description": "Icon picker control.",
+      "example": "{\n label: 'Page Icon',\n fieldname: 'page_icon',\n fieldtype: 'Icon'\n}"
+    },
+    {
+      "code": "frappe.meta.docfield_map['DocField'].fieldtype.formatter = (value) => { ... }",
+      "description": "You can add custom formatters for text type objects by adding them to the docfield object in frappe.meta.docfield_map.",
+      "example": "frappe.meta.docfield_map['DocField'].fieldtype.formatter = (value) => {\n if (value==='Section Break') return '🔵 Section Break';\n else return value;\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/controls.json
+++ b/data/cheatsheets/controls.json
@@ -1,0 +1,164 @@
+{
+  "title": "Controles",
+  "language": "es",
+  "tags": ["javascript", "ui", "controles"],
+  "items": [
+    {
+      "code": "frappe.ui.form.make_control({ parent, df })",
+      "description": "Crea un control de Frappe basado en las propiedades de 'df' y lo anexa al contenedor padre.",
+      "example": "frappe.ui.form.make_control({\n parent: $wrapper.find('.my-control'),\n df: {\n label: 'Fecha de Vencimiento',\n fieldname: 'due_date',\n fieldtype: 'Date'\n },\n render_input: true\n})"
+    },
+    {
+      "code": "{ fieldtype: 'Attach' }",
+      "description": "Control de adjuntar para subir archivos.",
+      "example": "{\n label: 'Adjunto',\n fieldname: 'attachment',\n fieldtype: 'Attach'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Attach Image' }",
+      "description": "Control de adjuntar imagen para subir imágenes.",
+      "example": "{\n label: 'Imagen de Usuario',\n fieldname: 'user_image',\n fieldtype: 'Attach Image'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Autocomplete' }",
+      "description": "Control de autocompletar para seleccionar de una lista de opciones.",
+      "example": "{\n label: 'Seleccionar Usuario',\n fieldname: 'user',\n fieldtype: 'Autocomplete',\n options: [\n 'faris@erpnext.com',\n 'suraj@erpnext.com'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Barcode' }",
+      "description": "Control de código de barras.",
+      "example": "{\n label: 'Código de Barras del Artículo',\n fieldname: 'item_barcode',\n fieldtype: 'Barcode'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Check' }",
+      "description": "Control de casilla de verificación.",
+      "example": "{\n label: 'Habilitar característica',\n fieldname: 'enable_feature',\n fieldtype: 'Check'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Code' }",
+      "description": "Control de editor de código con resaltado de sintaxis.",
+      "example": "{\n label: 'Script JS',\n fieldname: 'script',\n fieldtype: 'Code',\n options: 'Javascript',\n wrap: true,\n max_lines: 10,\n min_lines: 5\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Color' }",
+      "description": "Control de selector de color.",
+      "example": "{\n label: 'Tu color favorito',\n fieldname: 'user_color',\n fieldtype: 'Color'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Currency' }",
+      "description": "Control de entrada de moneda.",
+      "example": "{\n label: 'Monto',\n fieldname: 'amount',\n fieldtype: 'Currency',\n options: 'INR'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Data' }",
+      "description": "Control de entrada de datos genérico.",
+      "example": "{\n label: 'Nombre',\n fieldname: 'first_name',\n fieldtype: 'Data',\n options: 'Email'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Date Range' }",
+      "description": "Control de selector de rango de fechas.",
+      "example": "{\n label: 'Seleccionar Rango de Fechas',\n fieldname: 'date_range',\n fieldtype: 'Date Range'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Date' }",
+      "description": "Control de selector de fecha.",
+      "example": "{\n label: 'Fecha de Nacimiento',\n fieldname: 'birth_date',\n fieldtype: 'Date'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Datetime' }",
+      "description": "Control de selector de fecha y hora.",
+      "example": "{\n label: 'Fecha y Hora de Envío',\n fieldname: 'submission',\n fieldtype: 'Datetime'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Dynamic Link' }",
+      "description": "Control de enlace dinámico que enlaza a diferentes DocTypes.",
+      "example": "{\n label: 'Parte',\n fieldname: 'party',\n fieldtype: 'Dynamic Link',\n options: 'party_type'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Float' }",
+      "description": "Control de entrada de número flotante.",
+      "example": "{\n label: 'Umbral',\n fieldname: 'threshold',\n fieldtype: 'Float'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Geolocation' }",
+      "description": "Control de geolocalización.",
+      "example": "{\n label: 'Lugar de Reunión',\n fieldname: 'meeting_place',\n fieldtype: 'Geolocation'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'HTML Editor' }",
+      "description": "Control de editor HTML.",
+      "example": "{\n label: 'HTML Personalizado',\n fieldname: 'custom_html',\n fieldtype: 'HTML Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Int' }",
+      "description": "Control de entrada de entero.",
+      "example": "{\n label: 'Nro de días',\n fieldname: 'no_of_days',\n fieldtype: 'Int'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Link' }",
+      "description": "Control de enlace a otro DocType.",
+      "example": "{\n label: 'Seleccionar Usuario',\n fieldname: 'user',\n fieldtype: 'Link',\n options: 'User'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Markdown Editor' }",
+      "description": "Control de editor de Markdown.",
+      "example": "{\n label: 'Contenido del Blog',\n fieldname: 'content',\n fieldtype: 'Markdown Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'MultiCheck' }",
+      "description": "Control de múltiples casillas de verificación.",
+      "example": "{\n label: 'Contenido del Blog',\n fieldname: 'content',\n fieldtype: 'MultiCheck',\n options: [\n 'Opción 1',\n 'Opción 2',\n 'Opción 3',\n 'Opción 4',\n ],\n columns: 2\n}"
+    },
+    {
+      "code": "{ fieldtype: 'MultiSelect' }",
+      "description": "Control de menú desplegable de selección múltiple.",
+      "example": "{\n label: 'Seleccionar Usuarios',\n fieldname: 'users',\n fieldtype: 'MultiSelect',\n options: [\n 'faris@erpnext.com',\n 'suraj@erpnext.com',\n 'shivam@erpnext.com'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Password' }",
+      "description": "Control de entrada de contraseña.",
+      "example": "{\n label: 'Nueva Contraseña',\n fieldname: 'password',\n fieldtype: 'Password'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Rating' }",
+      "description": "Control de calificación.",
+      "example": "{\n label: 'Califica tu experiencia',\n fieldname: 'rating',\n fieldtype: 'Rating'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Select' }",
+      "description": "Control de menú desplegable de selección.",
+      "example": "{\n label: 'Estado',\n fieldname: 'status',\n fieldtype: 'Select',\n options: [\n 'Abierto',\n 'Cerrado',\n 'Cancelado'\n ]\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Signature' }",
+      "description": "Control de panel de firma.",
+      "example": "{\n label: 'Estado',\n fieldname: 'status',\n fieldtype: 'Signature'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Text Editor' }",
+      "description": "Control de editor de texto enriquecido.",
+      "example": "{\n label: 'Descripción',\n fieldname: 'description',\n fieldtype: 'Text Editor'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Time' }",
+      "description": "Control de selector de hora.",
+      "example": "{\n label: 'Hora de Entrada',\n fieldname: 'in_time',\n fieldtype: 'Time'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Button' }",
+      "description": "Control de botón.",
+      "example": "{\n label: 'Obtener',\n fieldname: 'fetch',\n fieldtype: 'Button',\n btn_size: 'xs'\n}"
+    },
+    {
+      "code": "{ fieldtype: 'Icon' }",
+      "description": "Control de selector de íconos.",
+      "example": "{\n label: 'Ícono de Página',\n fieldname: 'page_icon',\n fieldtype: 'Icon'\n}"
+    },
+    {
+      "code": "frappe.meta.docfield_map['DocField'].fieldtype.formatter = (value) => { ... }",
+      "description": "Puedes agregar formateadores personalizados para objetos de tipo texto agregándolos al objeto docfield en frappe.meta.docfield_map.",
+      "example": "frappe.meta.docfield_map['DocField'].fieldtype.formatter = (value) => {\n if (value==='Section Break') return '🔵 Salto de Sección';\n else return value;\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/database-py-en.json
+++ b/data/cheatsheets/database-py-en.json
@@ -1,0 +1,69 @@
+{
+  "title": "Database API (Python)",
+  "language": "en",
+  "tags": ["python", "database", "orm", "backend"],
+  "items": [
+    {
+      "code": "frappe.db.get_list(doctype, filters, fields, ...)",
+      "description": "Returns a list of records from a DocType, applying user permissions. Can specify filters, fields, ordering, and pagination.",
+      "example": "tasks = frappe.db.get_list('Task',\n    filters={'status': 'Open'},\n    fields=['subject', 'date'],\n    order_by='date desc'\n)"
+    },
+    {
+      "code": "frappe.db.get_all(doctype, filters, fields, ...)",
+      "description": "Similar to `get_list`, but fetches all records without applying user permissions.",
+      "example": "all_users = frappe.db.get_all('User', fields=['name', 'full_name'])"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name | filters, fieldname | [fieldnames])",
+      "description": "Returns a single field value or a list/dict of field values for a specific document.",
+      "example": "# Get a single value\nsubject = frappe.db.get_value('Task', 'TASK00002', 'subject')\n\n# Get multiple values as a dict\ntask_dict = frappe.db.get_value('Task', 'TASK00002', ['subject', 'description'], as_dict=True)"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, fieldname)",
+      "description": "Returns a field value from a Single DocType.",
+      "example": "timezone = frappe.db.get_single_value('System Settings', 'language')"
+    },
+    {
+      "code": "frappe.db.set_value(doctype, name, fieldname, value)",
+      "description": "Sets a field's value directly in the database. Does not call ORM triggers like `validate` or `on_update`.",
+      "example": "# Update a single field\nfrappe.db.set_value('Task', 'TASK00002', 'status', 'Completed')\n\n# Update multiple fields\nfrappe.db.set_value('Task', 'TASK00002', {\n    'status': 'Completed',\n    'priority': 'High'\n})"
+    },
+    {
+      "code": "frappe.db.exists(doctype, name | filters)",
+      "description": "Returns `True` if a document record exists, identified by name or filters.",
+      "example": "if frappe.db.exists('User', 'jane@example.com'):\n    # User exists"
+    },
+    {
+      "code": "frappe.db.count(doctype, filters)",
+      "description": "Returns the number of records for a given DocType and optional filters.",
+      "example": "open_tasks_count = frappe.db.count('Task', {'status': 'Open'})"
+    },
+    {
+      "code": "frappe.db.delete(doctype, filters)",
+      "description": "Deletes records that match the given filters. This is a reversible DML command.",
+      "example": "frappe.db.delete('Error Log', {'modified': ('<', '2023-01-01')})"
+    },
+    {
+      "code": "frappe.db.truncate(doctype)",
+      "description": "Truncates a table, deleting all its records. This is an irreversible DDL command.",
+      "example": "frappe.db.truncate('Error Log')"
+    },
+    {
+      "code": "frappe.db.sql(query, values, as_dict)",
+      "description": "Executes an arbitrary SQL query. Should be used with caution as it bypasses the ORM.",
+      "example": "data = frappe.db.sql('''SELECT name, status FROM `tabTask` WHERE priority=%(priority)s''',\n    values={'priority': 'High'},\n    as_dict=True\n)"
+    },
+    {
+      "code": "frappe.db.commit()",
+      "description": "Commits the current database transaction.",
+      "example": "frappe.db.commit()"
+    },
+    {
+      "code": "frappe.db.rollback()",
+      "description": "Rolls back the current database transaction.",
+      "example": "frappe.db.rollback()"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/database-py.json
+++ b/data/cheatsheets/database-py.json
@@ -1,0 +1,69 @@
+{
+  "title": "API de Base de Datos (Python)",
+  "language": "es",
+  "tags": ["python", "database", "orm", "backend"],
+  "items": [
+    {
+      "code": "frappe.db.get_list(doctype, filters, fields, ...)",
+      "description": "Devuelve una lista de registros de un DocType, aplicando permisos de usuario. Puede especificar filtros, campos, orden y paginación.",
+      "example": "tasks = frappe.db.get_list('Task',\n    filters={'status': 'Abierto'},\n    fields=['subject', 'date'],\n    order_by='date desc'\n)"
+    },
+    {
+      "code": "frappe.db.get_all(doctype, filters, fields, ...)",
+      "description": "Similar a `get_list`, pero obtiene todos los registros sin aplicar permisos de usuario.",
+      "example": "all_users = frappe.db.get_all('User', fields=['name', 'full_name'])"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name | filters, fieldname | [fieldnames])",
+      "description": "Devuelve el valor de un solo campo o una lista/diccionario de valores de campo para un documento específico.",
+      "example": "# Obtener un solo valor\nsubject = frappe.db.get_value('Task', 'TASK00002', 'subject')\n\n# Obtener múltiples valores como un diccionario\ntask_dict = frappe.db.get_value('Task', 'TASK00002', ['subject', 'description'], as_dict=True)"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, fieldname)",
+      "description": "Devuelve el valor de un campo de un DocType Single.",
+      "example": "timezone = frappe.db.get_single_value('System Settings', 'language')"
+    },
+    {
+      "code": "frappe.db.set_value(doctype, name, fieldname, value)",
+      "description": "Establece el valor de un campo directamente en la base de datos. No llama a los disparadores del ORM como `validate` o `on_update`.",
+      "example": "# Actualizar un solo campo\nfrappe.db.set_value('Task', 'TASK00002', 'status', 'Completado')\n\n# Actualizar múltiples campos\nfrappe.db.set_value('Task', 'TASK00002', {\n    'status': 'Completado',\n    'priority': 'Alto'\n})"
+    },
+    {
+      "code": "frappe.db.exists(doctype, name | filters)",
+      "description": "Devuelve `True` si existe un registro de documento, identificado por nombre o filtros.",
+      "example": "if frappe.db.exists('User', 'jane@example.com'):\n    # El usuario existe"
+    },
+    {
+      "code": "frappe.db.count(doctype, filters)",
+      "description": "Devuelve el número de registros para un DocType dado y filtros opcionales.",
+      "example": "open_tasks_count = frappe.db.count('Task', {'status': 'Abierto'})"
+    },
+    {
+      "code": "frappe.db.delete(doctype, filters)",
+      "description": "Elimina los registros que coinciden con los filtros dados. Este es un comando DML reversible.",
+      "example": "frappe.db.delete('Error Log', {'modified': ('<', '2023-01-01')})"
+    },
+    {
+      "code": "frappe.db.truncate(doctype)",
+      "description": "Trunca una tabla, eliminando todos sus registros. Este es un comando DDL irreversible.",
+      "example": "frappe.db.truncate('Error Log')"
+    },
+    {
+      "code": "frappe.db.sql(query, values, as_dict)",
+      "description": "Ejecuta una consulta SQL arbitraria. Debe usarse con precaución ya que omite el ORM.",
+      "example": "data = frappe.db.sql('''SELECT name, status FROM `tabTask` WHERE priority=%(priority)s''',\n    values={'priority': 'Alto'},\n    as_dict=True\n)"
+    },
+    {
+      "code": "frappe.db.commit()",
+      "description": "Confirma la transacción actual de la base de datos.",
+      "example": "frappe.db.commit()"
+    },
+    {
+      "code": "frappe.db.rollback()",
+      "description": "Revierte la transacción actual de la base de datos.",
+      "example": "frappe.db.rollback()"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/dialog-api-en.json
+++ b/data/cheatsheets/dialog-api-en.json
@@ -1,0 +1,59 @@
+{
+  "title": "Dialog API",
+  "language": "en",
+  "tags": ["javascript", "ui", "dialog"],
+  "items": [
+    {
+      "code": "new frappe.ui.Dialog({ title, fields, primary_action })",
+      "description": "Creates a new Dialog instance.",
+      "example": "let d = new frappe.ui.Dialog({\n    title: 'Enter details',\n    fields: [\n        {\n            label: 'First Name',\n            fieldname: 'first_name',\n            fieldtype: 'Data'\n        },\n        {\n            label: 'Last Name',\n            fieldname: 'last_name',\n            fieldtype: 'Data'\n        },\n        {\n            label: 'Age',\n            fieldname: 'age',\n            fieldtype: 'Int'\n        }\n    ],\n    size: 'small', // small, large, extra-large \n    primary_action_label: 'Submit',\n    primary_action(values) {\n        console.log(values);\n        d.hide();\n    }\n});\n\nd.show();"
+    },
+    {
+      "code": "frappe.msgprint(message | { title, message, indicator })",
+      "description": "Show a message in a modal. Can also have a primary action.",
+      "example": "// simple message\nfrappe.msgprint(__('Document updated successfully'));\n\n// with options\nfrappe.msgprint({\n    title: __('Notification'),\n    indicator: 'green',\n    message: __('Document updated successfully')\n});\n\n// with primary action\nfrappe.msgprint({\n    title: __('Notification'),\n    message: __('Are you sure you want to proceed?'),\n    primary_action:{\n        action(values) {\n            console.log(values);\n        }\n    }\n});"
+    },
+    {
+      "code": "frappe.throw(error_message)",
+      "description": "Show an error message in a modal and throw an exception.",
+      "example": "frappe.throw(__('This is an Error Message'))"
+    },
+    {
+      "code": "frappe.prompt(label | df | fields, callback)",
+      "description": "Prompt the user for one or more values.",
+      "example": "// prompt for a single value\nfrappe.prompt('First Name', ({ value }) => console.log(value))\n\n// prompt for multiple values\nfrappe.prompt([\n    {\n        label: 'First Name',\n        fieldname: 'first_name',\n        fieldtype: 'Data'\n    },\n    {\n        label: 'Last Name',\n        fieldname: 'last_name',\n        fieldtype: 'Data'\n    },\n], (values) => {\n    console.log(values.first_name, values.last_name);\n})"
+    },
+    {
+      "code": "frappe.confirm(message, if_yes, if_no)",
+      "description": "Show a confirmation modal and execute a callback based on the user's choice.",
+      "example": "frappe.confirm('Are you sure you want to proceed?',\n    () => {\n        // action to perform if Yes is selected\n    }, () => {\n        // action to perform if No is selected\n    })"
+    },
+    {
+      "code": "frappe.warn(title, message_html, proceed_action, primary_label, is_minimizable)",
+      "description": "Show a warning modal that can be minimized.",
+      "example": "frappe.warn('Are you sure you want to proceed?',\n    'There are unsaved changes on this page',\n    () => {\n        // action to perform if Continue is selected\n    },\n    'Continue',\n    true // Sets dialog as minimizable\n)"
+    },
+    {
+      "code": "frappe.show_alert(message | {message, indicator}, seconds)",
+      "description": "Shows a non-obstructive alert message for a few seconds.",
+      "example": "frappe.show_alert('Hi, you have a new message', 5);\n\n// with indicator\nfrappe.show_alert({\n    message:__('Hi, you have a new message'),\n    indicator:'green'\n}, 5);"
+    },
+    {
+      "code": "frappe.show_progress(title, count, total, description)",
+      "description": "Displays a progress bar.",
+      "example": "frappe.show_progress('Loading..', 70, 100, 'Please wait');"
+    },
+    {
+      "code": "frappe.new_doc(doctype, route_options, init_callback)",
+      "description": "Opens a new form for the specified DocType, with options to initialize fields.",
+      "example": "frappe.new_doc(\"Task\", {subject: \"New Task\"}, \n    doc => { doc.description = \"Do what's necessary\"; });"
+    },
+    {
+      "code": "new frappe.ui.form.MultiSelectDialog({ doctype, target, setters, ... })",
+      "description": "Creates a dialog for selecting multiple records from a DocType, with filtering and actions.",
+      "example": "new frappe.ui.form.MultiSelectDialog({\n    doctype: \"Material Request\",\n    target: this.cur_frm,\n    setters: {\n        schedule_date: null,\n        status: 'Pending'\n    },\n    get_query() {\n        return {\n            filters: { docstatus: ['!=', 2] }\n        }\n    },\n    action(selections) {\n        console.log(selections);\n    }\n});"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/dialog-api.json
+++ b/data/cheatsheets/dialog-api.json
@@ -1,0 +1,59 @@
+{
+  "title": "API de Diálogo",
+  "language": "es",
+  "tags": ["javascript", "ui", "dialogo"],
+  "items": [
+    {
+      "code": "new frappe.ui.Dialog({ title, fields, primary_action })",
+      "description": "Crea una nueva instancia de Diálogo.",
+      "example": "let d = new frappe.ui.Dialog({\n    title: 'Ingrese detalles',\n    fields: [\n        {\n            label: 'Nombre',\n            fieldname: 'first_name',\n            fieldtype: 'Data'\n        },\n        {\n            label: 'Apellido',\n            fieldname: 'last_name',\n            fieldtype: 'Data'\n        },\n        {\n            label: 'Edad',\n            fieldname: 'age',\n            fieldtype: 'Int'\n        }\n    ],\n    size: 'small', // small, large, extra-large \n    primary_action_label: 'Enviar',\n    primary_action(values) {\n        console.log(values);\n        d.hide();\n    }\n});\n\nd.show();"
+    },
+    {
+      "code": "frappe.msgprint(message | { title, message, indicator })",
+      "description": "Muestra un mensaje en un modal. También puede tener una acción principal.",
+      "example": "// mensaje simple\nfrappe.msgprint(__('Documento actualizado exitosamente'));\n\n// con opciones\nfrappe.msgprint({\n    title: __('Notificación'),\n    indicator: 'green',\n    message: __('Documento actualizado exitosamente')\n});\n\n// con acción principal\nfrappe.msgprint({\n    title: __('Notificación'),\n    message: __('¿Estás seguro de que quieres continuar?'),\n    primary_action:{\n        action(values) {\n            console.log(values);\n        }\n    }\n});"
+    },
+    {
+      "code": "frappe.throw(error_message)",
+      "description": "Muestra un mensaje de error en un modal y lanza una excepción.",
+      "example": "frappe.throw(__('Este es un Mensaje de Error'))"
+    },
+    {
+      "code": "frappe.prompt(label | df | fields, callback)",
+      "description": "Solicita al usuario uno o más valores.",
+      "example": "// solicitar un solo valor\nfrappe.prompt('Nombre', ({ value }) => console.log(value))\n\n// solicitar múltiples valores\nfrappe.prompt([\n    {\n        label: 'Nombre',\n        fieldname: 'first_name',\n        fieldtype: 'Data'\n    },\n    {\n        label: 'Apellido',\n        fieldname: 'last_name',\n        fieldtype: 'Data'\n    },\n], (values) => {\n    console.log(values.first_name, values.last_name);\n})"
+    },
+    {
+      "code": "frappe.confirm(message, if_yes, if_no)",
+      "description": "Muestra un modal de confirmación y ejecuta un callback basado en la elección del usuario.",
+      "example": "frappe.confirm('¿Estás seguro de que quieres continuar?',\n    () => {\n        // acción a realizar si se selecciona Sí\n    }, () => {\n        // acción a realizar si se selecciona No\n    })"
+    },
+    {
+      "code": "frappe.warn(title, message_html, proceed_action, primary_label, is_minimizable)",
+      "description": "Muestra un modal de advertencia que se puede minimizar.",
+      "example": "frappe.warn('¿Estás seguro de que quieres continuar?',\n    'Hay cambios sin guardar en esta página',\n    () => {\n        // acción a realizar si se selecciona Continuar\n    },\n    'Continuar',\n    true // Establece el diálogo como minimizable\n)"
+    },
+    {
+      "code": "frappe.show_alert(message | {message, indicator}, seconds)",
+      "description": "Muestra un mensaje de alerta no obstructivo durante unos segundos.",
+      "example": "frappe.show_alert('Hola, tienes un nuevo mensaje', 5);\n\n// con indicador\nfrappe.show_alert({\n    message:__('Hola, tienes un nuevo mensaje'),\n    indicator:'green'\n}, 5);"
+    },
+    {
+      "code": "frappe.show_progress(title, count, total, description)",
+      "description": "Muestra una barra de progreso.",
+      "example": "frappe.show_progress('Cargando..', 70, 100, 'Por favor espera');"
+    },
+    {
+      "code": "frappe.new_doc(doctype, route_options, init_callback)",
+      "description": "Abre un nuevo formulario para el DocType especificado, con opciones para inicializar campos.",
+      "example": "frappe.new_doc(\"Task\", {subject: \"Nueva Tarea\"}, \n    doc => { doc.description = \"Hacer lo necesario\"; });"
+    },
+    {
+      "code": "new frappe.ui.form.MultiSelectDialog({ doctype, target, setters, ... })",
+      "description": "Crea un diálogo para seleccionar múltiples registros de un DocType, con filtrado y acciones.",
+      "example": "new frappe.ui.form.MultiSelectDialog({\n    doctype: \"Material Request\",\n    target: this.cur_frm,\n    setters: {\n        schedule_date: null,\n        status: 'Pending'\n    },\n    get_query() {\n        return {\n            filters: { docstatus: ['!=', 2] }\n        }\n    },\n    action(selections) {\n        console.log(selections);\n    }\n});"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/dialog-py-en.json
+++ b/data/cheatsheets/dialog-py-en.json
@@ -1,0 +1,19 @@
+{
+  "title": "Dialog API (Python)",
+  "language": "en",
+  "tags": ["python", "dialog", "ui", "backend"],
+  "items": [
+    {
+      "code": "frappe.msgprint(msg, title, raise_exception, as_table, as_list, indicator, primary_action)",
+      "description": "Shows a message dialog to the user in the Desk UI who initiated the request. This method works only within a request-response cycle.",
+      "example": "# Simple message\nfrappe.msgprint('Document has been submitted successfully.')\n\n# Message with title and exception\nfrappe.msgprint(\n    msg='The selected file could not be found.',\n    title='Error',\n    raise_exception=FileNotFoundError\n)\n\n# Message with a primary action\nfrappe.msgprint(\n    msg='Do you want to proceed with this action?',\n    primary_action={\n        'label': 'Proceed',\n        'server_action': 'dotted.path.to.server.method',\n        'args': { 'id': 123 }\n    }\n)"
+    },
+    {
+      "code": "frappe.throw(msg, exc, title)",
+      "description": "A wrapper around `frappe.msgprint` that raises an exception and shows a message dialog to the user. By default, it raises a `frappe.ValidationError`.",
+      "example": "if not frappe.db.exists('User', 'test@example.com'):\n    frappe.throw(\n        msg='User not found. Please check the email address.',\n        title='Invalid User',\n        exc=frappe.DoesNotExistError\n    )"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/dialog-py.json
+++ b/data/cheatsheets/dialog-py.json
@@ -1,0 +1,19 @@
+{
+  "title": "API de Diálogo (Python)",
+  "language": "es",
+  "tags": ["python", "dialogo", "ui", "backend"],
+  "items": [
+    {
+      "code": "frappe.msgprint(msg, title, raise_exception, as_table, as_list, indicator, primary_action)",
+      "description": "Muestra un diálogo de mensaje al usuario en la interfaz de Desk que inició la solicitud. Este método solo funciona dentro de un ciclo de solicitud-respuesta.",
+      "example": "# Mensaje simple\nfrappe.msgprint('El documento se ha enviado correctamente.')\n\n# Mensaje con título y excepción\nfrappe.msgprint(\n    msg='No se pudo encontrar el archivo seleccionado.',\n    title='Error',\n    raise_exception=FileNotFoundError\n)\n\n# Mensaje con una acción principal\nfrappe.msgprint(\n    msg='¿Desea continuar con esta acción?',\n    primary_action={\n        'label': 'Proceder',\n        'server_action': 'ruta.punteada.al.metodo.servidor',\n        'args': { 'id': 123 }\n    }\n)"
+    },
+    {
+      "code": "frappe.throw(msg, exc, title)",
+      "description": "Un envoltorio alrededor de `frappe.msgprint` que lanza una excepción y muestra un diálogo de mensaje al usuario. Por defecto, lanza una `frappe.ValidationError`.",
+      "example": "if not frappe.db.exists('User', 'test@example.com'):\n    frappe.throw(\n        msg='Usuario no encontrado. Por favor, verifique la dirección de correo electrónico.',\n        title='Usuario no válido',\n        exc=frappe.DoesNotExistError\n    )"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/document-py-en.json
+++ b/data/cheatsheets/document-py-en.json
@@ -1,0 +1,69 @@
+{
+  "title": "Document API (Python)",
+  "language": "en",
+  "tags": ["python", "document", "orm", "backend"],
+  "items": [
+    {
+      "code": "frappe.get_doc(doctype, name)",
+      "description": "Returns a Document object for the given doctype and name. Raises DoesNotExistError if not found.",
+      "example": "# Get an existing document\ndoc = frappe.get_doc('Task', 'TASK00002')\ndoc.status = 'Completed'\ndoc.save()"
+    },
+    {
+      "code": "frappe.get_doc({ 'doctype': 'MyDoc', ... })",
+      "description": "Creates a new in-memory Document object from a dictionary. The document is not saved to the database yet.",
+      "example": "doc = frappe.get_doc({\n    'doctype': 'Task',\n    'subject': 'My new task from code'\n})\ndoc.insert()"
+    },
+    {
+      "code": "frappe.new_doc(doctype)",
+      "description": "A convenient way to create a new, empty Document object in memory.",
+      "example": "doc = frappe.new_doc('Task')\ndoc.subject = 'Another new task'\ndoc.status = 'Open'\ndoc.insert()"
+    },
+    {
+      "code": "frappe.delete_doc(doctype, name)",
+      "description": "Deletes a document and all its linked data (comments, timeline, etc.) from the database.",
+      "example": "frappe.delete_doc('Task', 'TASK00003')"
+    },
+    {
+      "code": "frappe.rename_doc(doctype, old_name, new_name)",
+      "description": "Renames a document's primary key (name). Requires 'Allow Rename' to be enabled on the DocType.",
+      "example": "frappe.rename_doc('Task', 'TASK00004', 'TASK-2023-001')"
+    },
+    {
+      "code": "doc.insert(ignore_permissions=False, ...)",
+      "description": "Inserts a new document into the database, running all controller hooks (e.g., `before_insert`, `validate`).",
+      "example": "new_task = frappe.get_doc({'doctype': 'Task', 'subject': 'Important Task'})\nnew_task.insert(ignore_permissions=True)"
+    },
+    {
+      "code": "doc.save(ignore_permissions=False, ...)",
+      "description": "Saves changes to an existing document, running controller hooks (e.g., `validate`, `on_update`).",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\ntask.priority = 'High'\ntask.save()"
+    },
+    {
+      "code": "doc.reload()",
+      "description": "Reloads the document from the database to get the latest state.",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\n# another process might change the doc here\ntask.reload()\nprint(task.status)"
+    },
+    {
+      "code": "doc.db_set(fieldname, value, commit=False)",
+      "description": "Sets a field's value directly in the database, bypassing ORM hooks and validations. Use with caution.",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\ntask.db_set('priority', 'Low') # Directly updates the DB"
+    },
+    {
+      "code": "doc.append(table_fieldname, { ... })",
+      "description": "Appends a new row to a child table (Table field) within the document.",
+      "example": "sales_order.append('items', {\n    'item_code': 'ITM001',\n    'qty': 5\n})"
+    },
+    {
+      "code": "doc.add_comment(comment_type, text)",
+      "description": "Adds a comment to the document's timeline.",
+      "example": "task.add_comment('Comment', text='This task is blocked by another issue.')"
+    },
+    {
+      "code": "doc.queue_action(method, **kwargs)",
+      "description": "Runs a controller method in a background job.",
+      "example": "doc.queue_action('send_follow_up_email', customer=doc.customer)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/document-py.json
+++ b/data/cheatsheets/document-py.json
@@ -1,0 +1,69 @@
+{
+  "title": "API de Documento (Python)",
+  "language": "es",
+  "tags": ["python", "documento", "orm", "backend"],
+  "items": [
+    {
+      "code": "frappe.get_doc(doctype, name)",
+      "description": "Devuelve un objeto Documento para el doctype y nombre dados. Lanza DoesNotExistError si no se encuentra.",
+      "example": "# Obtener un documento existente\ndoc = frappe.get_doc('Task', 'TASK00002')\ndoc.status = 'Completado'\ndoc.save()"
+    },
+    {
+      "code": "frappe.get_doc({ 'doctype': 'MyDoc', ... })",
+      "description": "Crea un nuevo objeto Documento en memoria a partir de un diccionario. El documento aún no se ha guardado en la base de datos.",
+      "example": "doc = frappe.get_doc({\n    'doctype': 'Task',\n    'subject': 'Mi nueva tarea desde código'\n})\ndoc.insert()"
+    },
+    {
+      "code": "frappe.new_doc(doctype)",
+      "description": "Una forma conveniente de crear un nuevo objeto Documento vacío en memoria.",
+      "example": "doc = frappe.new_doc('Task')\ndoc.subject = 'Otra nueva tarea'\ndoc.status = 'Abierto'\ndoc.insert()"
+    },
+    {
+      "code": "frappe.delete_doc(doctype, name)",
+      "description": "Elimina un documento y todos sus datos vinculados (comentarios, línea de tiempo, etc.) de la base de datos.",
+      "example": "frappe.delete_doc('Task', 'TASK00003')"
+    },
+    {
+      "code": "frappe.rename_doc(doctype, old_name, new_name)",
+      "description": "Renombra la clave primaria (nombre) de un documento. Requiere que 'Permitir Renombrar' esté habilitado en el DocType.",
+      "example": "frappe.rename_doc('Task', 'TASK00004', 'TASK-2023-001')"
+    },
+    {
+      "code": "doc.insert(ignore_permissions=False, ...)",
+      "description": "Inserta un nuevo documento en la base de datos, ejecutando todos los ganchos del controlador (ej. `before_insert`, `validate`).",
+      "example": "new_task = frappe.get_doc({'doctype': 'Task', 'subject': 'Tarea Importante'})\nnew_task.insert(ignore_permissions=True)"
+    },
+    {
+      "code": "doc.save(ignore_permissions=False, ...)",
+      "description": "Guarda los cambios en un documento existente, ejecutando los ganchos del controlador (ej. `validate`, `on_update`).",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\ntask.priority = 'Alto'\ntask.save()"
+    },
+    {
+      "code": "doc.reload()",
+      "description": "Recarga el documento desde la base de datos para obtener el estado más reciente.",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\n# otro proceso podría cambiar el doc aquí\ntask.reload()\nprint(task.status)"
+    },
+    {
+      "code": "doc.db_set(fieldname, value, commit=False)",
+      "description": "Establece el valor de un campo directamente en la base de datos, omitiendo los ganchos y validaciones del ORM. Usar con precaución.",
+      "example": "task = frappe.get_doc('Task', 'TASK00001')\ntask.db_set('priority', 'Bajo') # Actualiza directamente la BD"
+    },
+    {
+      "code": "doc.append(table_fieldname, { ... })",
+      "description": "Añade una nueva fila a una tabla hija (campo Tabla) dentro del documento.",
+      "example": "sales_order.append('items', {\n    'item_code': 'ITM001',\n    'qty': 5\n})"
+    },
+    {
+      "code": "doc.add_comment(comment_type, text)",
+      "description": "Añade un comentario a la línea de tiempo del documento.",
+      "example": "task.add_comment('Comment', text='Esta tarea está bloqueada por otro problema.')"
+    },
+    {
+      "code": "doc.queue_action(method, **kwargs)",
+      "description": "Ejecuta un método del controlador en un trabajo en segundo plano.",
+      "example": "doc.queue_action('send_follow_up_email', customer=doc.customer)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/form-en.json
+++ b/data/cheatsheets/form-en.json
@@ -1,0 +1,129 @@
+{
+  "title": "Form Scripts",
+  "language": "en",
+  "tags": ["javascript", "form", "api"],
+  "items": [
+    {
+      "code": "frappe.ui.form.on(doctype, { ... })",
+      "description": "Standard syntax for creating Form Scripts. You can define multiple event handlers within the object.",
+      "example": "frappe.ui.form.on('ToDo', {\n    refresh(frm) {\n        if (frm.doc.reference_type && frm.doc.reference_name) {\n            frm.add_custom_button(__(frm.doc.reference_name), () => {\n                frappe.set_route(\"Form\", frm.doc.reference_type, frm.doc.reference_name);\n            });\n        }\n    }\n})"
+    },
+    {
+      "code": "frappe.ui.form.on('Child DocType', { ... })",
+      "description": "Syntax for creating Child Table Scripts. These should be written in the same file as their parent.",
+      "example": "frappe.ui.form.on('Quotation Item', {\n    item_code(frm, cdt, cdn) {\n        let row = frappe.get_doc(cdt, cdn);\n        // logic here\n    }\n})"
+    },
+    {
+      "code": "frm.set_value(fieldname, value)",
+      "description": "Set the value of a single field. This triggers the field's change event.",
+      "example": "frm.set_value('description', 'New description');"
+    },
+    {
+      "code": "frm.set_value({ fieldname: value, ... })",
+      "description": "Set the values of multiple fields at once.",
+      "example": "frm.set_value({\n    status: 'Open',\n    description: 'New description'\n});"
+    },
+    {
+      "code": "frm.refresh()",
+      "description": "Refresh the form with the latest values from the server.",
+      "example": "frm.refresh();"
+    },
+    {
+      "code": "frm.save()",
+      "description": "Trigger a form save. Can also be used for Submit, Cancel, and Update actions.",
+      "example": "// save form\nfrm.save();\n\n// submit form\nfrm.save('Submit');"
+    },
+    {
+      "code": "frm.enable_save() / frm.disable_save()",
+      "description": "Enable or disable the Save button in the form.",
+      "example": "if (frappe.user_roles.includes('Custom Role')) {\n    frm.enable_save();\n} else {\n    frm.disable_save();\n}"
+    },
+    {
+      "code": "frm.email_doc(message)",
+      "description": "Open the Email dialog for the current form, optionally with a pre-filled message.",
+      "example": "frm.email_doc(`Hello ${frm.doc.customer_name}`);"
+    },
+    {
+      "code": "frm.reload_doc()",
+      "description": "Reload the document with the latest values and refresh the form.",
+      "example": "frm.reload_doc();"
+    },
+    {
+      "code": "frm.refresh_field(fieldname)",
+      "description": "Refresh a specific field and its dependencies.",
+      "example": "frm.refresh_field('description');"
+    },
+    {
+      "code": "frm.is_dirty()",
+      "description": "Check if form values have been changed and are not saved yet.",
+      "example": "if (frm.is_dirty()) {\n    frappe.show_alert('Please save form before attaching a file')\n}"
+    },
+    {
+      "code": "frm.dirty()",
+      "description": "Manually set the form as 'dirty' to indicate unsaved changes.",
+      "example": "frm.doc.browser_data = navigator.appVersion;\nfrm.dirty();"
+    },
+    {
+      "code": "frm.is_new()",
+      "description": "Check if the form is for a new document that has not been saved yet.",
+      "example": "if (!frm.is_new()) {\n    frm.add_custom_button('Click me', () => console.log('Clicked'));\n}"
+    },
+    {
+      "code": "frm.set_intro(message, color)",
+      "description": "Set an introductory text at the top of the form.",
+      "example": "frm.set_intro('Please set the value of description', 'blue');"
+    },
+    {
+      "code": "frm.add_custom_button(label, action, group)",
+      "description": "Add a custom button to the form's inner toolbar.",
+      "example": "frm.add_custom_button('Open Reference', () => {\n    frappe.set_route('Form', frm.doc.reference_type, frm.doc.reference_name);\n});"
+    },
+    {
+      "code": "frm.set_df_property(fieldname, property, value)",
+      "description": "Change a property of a field's DocField and refresh it.",
+      "example": "// set a field as mandatory\nfrm.set_df_property('title', 'reqd', 1);\n\n// set a field as read only\nfrm.set_df_property('status', 'read_only', 1);"
+    },
+    {
+      "code": "frm.toggle_enable(fields, condition)",
+      "description": "Toggle the read-only state of fields based on a condition.",
+      "example": "let is_allowed = frappe.user_roles.includes('System Manager');\nfrm.toggle_enable(['status', 'priority'], is_allowed);"
+    },
+    {
+      "code": "frm.toggle_reqd(fields, condition)",
+      "description": "Toggle the mandatory state of fields based on a condition.",
+      "example": "frm.toggle_reqd('priority', frm.doc.status === 'Open');"
+    },
+    {
+      "code": "frm.toggle_display(fields, condition)",
+      "description": "Show or hide fields based on a condition.",
+      "example": "frm.toggle_display(['priority', 'due_date'], frm.doc.status === 'Open');"
+    },
+    {
+      "code": "frm.set_query(fieldname, [table_fieldname], () => { ... })",
+      "description": "Apply filters to a Link field to limit the selectable records.",
+      "example": "// Filter customers by territory\nfrm.set_query('customer', () => {\n    return {\n        filters: {\n            territory: 'India'\n        }\n    }\n});\n\n// Filter items in a child table\nfrm.set_query('item_code', 'items', () => {\n    return {\n        filters: {\n            item_group: 'Products'\n        }\n    }\n});"
+    },
+    {
+      "code": "frm.add_child(table_fieldname, { ... })",
+      "description": "Add a new row to a child table with the specified values.",
+      "example": "let row = frm.add_child('items', {\n    item_code: 'Tennis Racket',\n    qty: 2\n});\nfrm.refresh_field('items');"
+    },
+    {
+      "code": "frm.call(method, args)",
+      "description": "Call a whitelisted server-side controller method with arguments.",
+      "example": "frm.call('get_linked_doc', { throw_if_missing: true })\n .then(r => {\n     if (r.message) {\n         let linked_doc = r.message;\n         // do something with linked_doc\n     }\n })"
+    },
+    {
+      "code": "frm.trigger(event_name)",
+      "description": "Trigger a form event explicitly.",
+      "example": "frm.trigger('set_mandatory_fields');"
+    },
+    {
+      "code": "frm.get_selected()",
+      "description": "Get the selected rows in all child tables.",
+      "example": "let selected = frm.get_selected();\n// { items: [\"bbfcb8da6a\"], taxes: [\"036ab9452a\"] }"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/form-tours-en.json
+++ b/data/cheatsheets/form-tours-en.json
@@ -1,0 +1,29 @@
+{
+  "title": "Form Tours",
+  "language": "en",
+  "tags": ["javascript", "form", "tour", "tutorial"],
+  "items": [
+    {
+      "code": "New Form Tour",
+      "description": "To create a new Form Tour, type 'new form tour' in the awesomebar and hit enter. You will need to enter a title, select a reference DocType, and add steps for each field.",
+      "example": "// Navigate to 'new form tour' via the awesomebar to start creating a tour."
+    },
+    {
+      "code": "Form Tour Configuration",
+      "description": "Key configuration options for a Form Tour document.",
+      "example": "/*\n- Is Standard: Makes the tour a standard one stored as JSON (developer mode only).\n- Save on Completion: Prompts the user to save the document at the end of the tour.\n- Show First Document Tour: Shows the tour on the first existing document instead of a new form.\n- Include Name Field: Makes the 'name' field the first step of the tour.\n*/"
+    },
+    {
+      "code": "Form Tour Step Configuration",
+      "description": "Key configuration options for each step in a Form Tour.",
+      "example": "/*\n- Field: The field to be highlighted.\n- Title & Description: Text to describe the highlighted field.\n- Position: Position of the popover (e.g., 'Top', 'Bottom', 'Left', 'Right').\n- Next Condition: A JavaScript condition (e.g., 'eval: doc.priority != \"\"') that must be met to proceed to the next step.\n- Is Table Field: Check if the field is within a child table.\n- Parent Field: The parent table field if 'Is Table Field' is checked.\n*/"
+    },
+    {
+      "code": "frm.tour.init({ tour_name }).then(() => frm.tour.start())",
+      "description": "Initializes and starts a Form Tour. This is typically done in the 'onload' event of a form script.",
+      "example": "frappe.ui.form.on('Custom Field', 'onload', () => {\n const tour_name = 'Creating a Custom Field';\n frm.tour\n .init({ tour_name })\n .then(() => frm.tour.start());\n});"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/form-tours.json
+++ b/data/cheatsheets/form-tours.json
@@ -1,0 +1,29 @@
+{
+  "title": "Recorridos de Formulario",
+  "language": "es",
+  "tags": ["javascript", "formulario", "recorrido", "tutorial"],
+  "items": [
+    {
+      "code": "Nuevo Recorrido de Formulario",
+      "description": "Para crear un nuevo Recorrido de Formulario, escribe 'nuevo recorrido de formulario' en la barra de búsqueda (awesomebar) y presiona Enter. Deberás ingresar un título, seleccionar un DocType de referencia y agregar pasos para cada campo.",
+      "example": "// Navega a 'nuevo recorrido de formulario' a través de la awesomebar para comenzar a crear un recorrido."
+    },
+    {
+      "code": "Configuración del Recorrido de Formulario",
+      "description": "Opciones de configuración clave para un documento de Recorrido de Formulario.",
+      "example": "/*\n- Es Estándar: Convierte el recorrido en uno estándar almacenado como JSON (solo en modo desarrollador).\n- Guardar al Completar: Pide al usuario que guarde el documento al final del recorrido.\n- Mostrar Primer Recorrido de Documento: Muestra el recorrido en el primer documento existente en lugar de un formulario nuevo.\n- Incluir Campo de Nombre: Hace que el campo 'name' sea el primer paso del recorrido.\n*/"
+    },
+    {
+      "code": "Configuración de Pasos del Recorrido de Formulario",
+      "description": "Opciones de configuración clave para cada paso en un Recorrido de Formulario.",
+      "example": "/*\n- Campo: El campo a resaltar.\n- Título y Descripción: Texto para describir el campo resaltado.\n- Posición: Posición del popover (ej. 'Arriba', 'Abajo', 'Izquierda', 'Derecha').\n- Condición Siguiente: Una condición de JavaScript (ej. 'eval: doc.priority != \"\"') que debe cumplirse para pasar al siguiente paso.\n- Es Campo de Tabla: Marcar si el campo está dentro de una tabla hija.\n- Campo Padre: El campo de la tabla padre si 'Es Campo de Tabla' está marcado.\n*/"
+    },
+    {
+      "code": "frm.tour.init({ tour_name }).then(() => frm.tour.start())",
+      "description": "Inicializa e inicia un Recorrido de Formulario. Esto se hace típicamente en el evento 'onload' de un script de formulario.",
+      "example": "frappe.ui.form.on('Custom Field', 'onload', () => {\n const tour_name = 'Creando un Campo Personalizado';\n frm.tour\n .init({ tour_name })\n .then(() => frm.tour.start());\n});"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/form.json
+++ b/data/cheatsheets/form.json
@@ -1,0 +1,129 @@
+{
+  "title": "Scripts de Formulario",
+  "language": "es",
+  "tags": ["javascript", "formulario", "api"],
+  "items": [
+    {
+      "code": "frappe.ui.form.on(doctype, { ... })",
+      "description": "Sintaxis estándar para crear Scripts de Formulario. Puedes definir múltiples manejadores de eventos dentro del objeto.",
+      "example": "frappe.ui.form.on('ToDo', {\n    refresh(frm) {\n        if (frm.doc.reference_type && frm.doc.reference_name) {\n            frm.add_custom_button(__(frm.doc.reference_name), () => {\n                frappe.set_route(\"Form\", frm.doc.reference_type, frm.doc.reference_name);\n            });\n        }\n    }\n})"
+    },
+    {
+      "code": "frappe.ui.form.on('Child DocType', { ... })",
+      "description": "Sintaxis para crear Scripts de Tabla Hija. Estos deben escribirse en el mismo archivo que su padre.",
+      "example": "frappe.ui.form.on('Quotation Item', {\n    item_code(frm, cdt, cdn) {\n        let row = frappe.get_doc(cdt, cdn);\n        // lógica aquí\n    }\n})"
+    },
+    {
+      "code": "frm.set_value(fieldname, value)",
+      "description": "Establece el valor de un solo campo. Esto dispara el evento de cambio del campo.",
+      "example": "frm.set_value('description', 'Nueva descripción');"
+    },
+    {
+      "code": "frm.set_value({ fieldname: value, ... })",
+      "description": "Establece los valores de múltiples campos a la vez.",
+      "example": "frm.set_value({\n    status: 'Abierto',\n    description: 'Nueva descripción'\n});"
+    },
+    {
+      "code": "frm.refresh()",
+      "description": "Refresca el formulario con los últimos valores del servidor.",
+      "example": "frm.refresh();"
+    },
+    {
+      "code": "frm.save()",
+      "description": "Dispara el guardado del formulario. También se puede usar para las acciones Enviar, Cancelar y Actualizar.",
+      "example": "// guardar formulario\nfrm.save();\n\n// enviar formulario\nfrm.save('Submit');"
+    },
+    {
+      "code": "frm.enable_save() / frm.disable_save()",
+      "description": "Habilita o deshabilita el botón Guardar en el formulario.",
+      "example": "if (frappe.user_roles.includes('Rol Personalizado')) {\n    frm.enable_save();\n} else {\n    frm.disable_save();\n}"
+    },
+    {
+      "code": "frm.email_doc(message)",
+      "description": "Abre el diálogo de Correo Electrónico para el formulario actual, opcionalmente con un mensaje pre-rellenado.",
+      "example": "frm.email_doc(`Hola ${frm.doc.customer_name}`);"
+    },
+    {
+      "code": "frm.reload_doc()",
+      "description": "Recarga el documento con los últimos valores y refresca el formulario.",
+      "example": "frm.reload_doc();"
+    },
+    {
+      "code": "frm.refresh_field(fieldname)",
+      "description": "Refresca un campo específico y sus dependencias.",
+      "example": "frm.refresh_field('description');"
+    },
+    {
+      "code": "frm.is_dirty()",
+      "description": "Verifica si los valores del formulario han cambiado y aún no se han guardado.",
+      "example": "if (frm.is_dirty()) {\n    frappe.show_alert('Por favor, guarde el formulario antes de adjuntar un archivo')\n}"
+    },
+    {
+      "code": "frm.dirty()",
+      "description": "Establece manualmente el formulario como 'sucio' para indicar cambios no guardados.",
+      "example": "frm.doc.browser_data = navigator.appVersion;\nfrm.dirty();"
+    },
+    {
+      "code": "frm.is_new()",
+      "description": "Verifica si el formulario es para un documento nuevo que aún no se ha guardado.",
+      "example": "if (!frm.is_new()) {\n    frm.add_custom_button('Haz clic', () => console.log('Clickeado'));\n}"
+    },
+    {
+      "code": "frm.set_intro(message, color)",
+      "description": "Establece un texto introductorio en la parte superior del formulario.",
+      "example": "frm.set_intro('Por favor, establezca el valor de la descripción', 'blue');"
+    },
+    {
+      "code": "frm.add_custom_button(label, action, group)",
+      "description": "Agrega un botón personalizado a la barra de herramientas interna del formulario.",
+      "example": "frm.add_custom_button('Abrir Referencia', () => {\n    frappe.set_route('Form', frm.doc.reference_type, frm.doc.reference_name);\n});"
+    },
+    {
+      "code": "frm.set_df_property(fieldname, property, value)",
+      "description": "Cambia una propiedad del DocField de un campo y lo refresca.",
+      "example": "// establecer un campo como obligatorio\nfrm.set_df_property('title', 'reqd', 1);\n\n// establecer un campo como solo lectura\nfrm.set_df_property('status', 'read_only', 1);"
+    },
+    {
+      "code": "frm.toggle_enable(fields, condition)",
+      "description": "Activa o desactiva el estado de solo lectura de los campos según una condición.",
+      "example": "let is_allowed = frappe.user_roles.includes('System Manager');\nfrm.toggle_enable(['status', 'priority'], is_allowed);"
+    },
+    {
+      "code": "frm.toggle_reqd(fields, condition)",
+      "description": "Activa o desactiva el estado de obligatorio de los campos según una condición.",
+      "example": "frm.toggle_reqd('priority', frm.doc.status === 'Abierto');"
+    },
+    {
+      "code": "frm.toggle_display(fields, condition)",
+      "description": "Muestra u oculta campos según una condición.",
+      "example": "frm.toggle_display(['priority', 'due_date'], frm.doc.status === 'Abierto');"
+    },
+    {
+      "code": "frm.set_query(fieldname, [table_fieldname], () => { ... })",
+      "description": "Aplica filtros a un campo de tipo Link para limitar los registros seleccionables.",
+      "example": "// Filtrar clientes por territorio\nfrm.set_query('customer', () => {\n    return {\n        filters: {\n            territory: 'India'\n        }\n    }\n});\n\n// Filtrar artículos en una tabla hija\nfrm.set_query('item_code', 'items', () => {\n    return {\n        filters: {\n            item_group: 'Productos'\n        }\n    }\n});"
+    },
+    {
+      "code": "frm.add_child(table_fieldname, { ... })",
+      "description": "Agrega una nueva fila a una tabla hija con los valores especificados.",
+      "example": "let row = frm.add_child('items', {\n    item_code: 'Raqueta de Tenis',\n    qty: 2\n});\nfrm.refresh_field('items');"
+    },
+    {
+      "code": "frm.call(method, args)",
+      "description": "Llama a un método de controlador del lado del servidor en la lista blanca con argumentos.",
+      "example": "frm.call('get_linked_doc', { throw_if_missing: true })\n .then(r => {\n     if (r.message) {\n         let linked_doc = r.message;\n         // hacer algo con linked_doc\n     }\n })"
+    },
+    {
+      "code": "frm.trigger(event_name)",
+      "description": "Dispara un evento de formulario explícitamente.",
+      "example": "frm.trigger('set_mandatory_fields');"
+    },
+    {
+      "code": "frm.get_selected()",
+      "description": "Obtiene las filas seleccionadas en todas las tablas hijas.",
+      "example": "let selected = frm.get_selected();\n// { items: [\"bbfcb8da6a\"], taxes: [\"036ab9452a\"] }"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/full-text-search-api-en.json
+++ b/data/cheatsheets/full-text-search-api-en.json
@@ -1,0 +1,34 @@
+{
+  "title": "Full-Text Search API (Python)",
+  "language": "en",
+  "tags": ["python", "search", "whoosh", "backend"],
+  "items": [
+    {
+      "code": "search_instance.search(text, scope=None, limit=20)",
+      "description": "Searches the index for a given text string, with an optional scope and limit for the number of results.",
+      "example": "# Assuming 'search_instance' is an instance of FullTextSearch\nresults = search_instance.search('erpnext', scope='documentation', limit=10)"
+    },
+    {
+      "code": "search_instance.update_index_by_name(doc_name)",
+      "description": "Updates the search index for a single document specified by its name. Should be run by an administrator or in a background job.",
+      "example": "# Assuming 'search_instance' is an instance of FullTextSearch\nsearch_instance.update_index_by_name('DOC-001')"
+    },
+    {
+      "code": "search_instance.update_index(document)",
+      "description": "Updates the search index for a given document object. The document should be a dictionary with 'title', 'path', and 'content' keys.",
+      "example": "doc_to_index = {\n    'title': 'My New Document',\n    'path': '/docs/my-new-document',\n    'content': 'This is the content of the new document.'\n}\nsearch_instance.update_index(doc_to_index)"
+    },
+    {
+      "code": "search_instance.remove_document_from_index(doc_name)",
+      "description": "Removes a specific document from the search index by its name.",
+      "example": "search_instance.remove_document_from_index('DOC-001')"
+    },
+    {
+      "code": "search_instance.build_index()",
+      "description": "Builds or rebuilds the entire search index for all parsed documents.",
+      "example": "search_instance.build_index()"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/full-text-search-api.json
+++ b/data/cheatsheets/full-text-search-api.json
@@ -1,0 +1,34 @@
+{
+  "title": "API de Búsqueda de Texto Completo (Python)",
+  "language": "es",
+  "tags": ["python", "busqueda", "whoosh", "backend"],
+  "items": [
+    {
+      "code": "search_instance.search(text, scope=None, limit=20)",
+      "description": "Busca en el índice una cadena de texto dada, con un alcance opcional y un límite para el número de resultados.",
+      "example": "# Suponiendo que 'search_instance' es una instancia de FullTextSearch\nresults = search_instance.search('erpnext', scope='documentation', limit=10)"
+    },
+    {
+      "code": "search_instance.update_index_by_name(doc_name)",
+      "description": "Actualiza el índice de búsqueda para un único documento especificado por su nombre. Debe ser ejecutado por un administrador o en un trabajo en segundo plano.",
+      "example": "# Suponiendo que 'search_instance' es una instancia de FullTextSearch\nsearch_instance.update_index_by_name('DOC-001')"
+    },
+    {
+      "code": "search_instance.update_index(document)",
+      "description": "Actualiza el índice de búsqueda para un objeto de documento dado. El documento debe ser un diccionario con las claves 'title', 'path' y 'content'.",
+      "example": "doc_to_index = {\n    'title': 'Mi Nuevo Documento',\n    'path': '/docs/mi-nuevo-documento',\n    'content': 'Este es el contenido del nuevo documento.'\n}\nsearch_instance.update_index(doc_to_index)"
+    },
+    {
+      "code": "search_instance.remove_document_from_index(doc_name)",
+      "description": "Elimina un documento específico del índice de búsqueda por su nombre.",
+      "example": "search_instance.remove_document_from_index('DOC-001')"
+    },
+    {
+      "code": "search_instance.build_index()",
+      "description": "Construye o reconstruye todo el índice de búsqueda para todos los documentos analizados.",
+      "example": "search_instance.build_index()"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/hooks-py-en.json
+++ b/data/cheatsheets/hooks-py-en.json
@@ -1,0 +1,69 @@
+{
+  "title": "Frappe Hooks (Python)",
+  "language": "en",
+  "tags": ["python", "hooks", "backend", "customization"],
+  "items": [
+    {
+      "code": "doc_events = { ... }",
+      "description": "Hooks into document CRUD (Create, Read, Update, Delete) events. Allows running custom code before or after actions like `validate`, `on_submit`, `on_cancel`, etc.",
+      "example": "doc_events = {\n    \"Task\": {\n        \"on_update\": \"my_app.tasks.on_task_update\"\n    },\n    \"*\": {\n        \"after_insert\": \"my_app.utils.log_all_inserts\"\n    }\n}"
+    },
+    {
+      "code": "scheduler_events = { ... }",
+      "description": "Schedules Python functions to run periodically in the background. Supports cron syntax and presets like `hourly`, `daily`, `weekly`, `monthly`.",
+      "example": "scheduler_events = {\n    \"daily\": [\n        \"my_app.tasks.cleanup_old_logs\"\n    ],\n    \"cron\": {\n        \"*/15 * * * *\": [\n            \"my_app.tasks.check_system_health\"\n        ]\n    }\n}"
+    },
+    {
+      "code": "override_whitelisted_methods = { ... }",
+      "description": "Replaces a standard whitelisted method with your own custom implementation. Useful for changing core API behavior.",
+      "example": "override_whitelisted_methods = {\n    \"frappe.client.get_count\": \"my_app.overrides.custom_get_count\"\n}"
+    },
+    {
+      "code": "permission_query_conditions = { ... }",
+      "description": "Applies additional SQL `WHERE` conditions to list queries (`frappe.db.get_list`), allowing for fine-grained record-level security based on the user.",
+      "example": "permission_query_conditions = {\n    \"Project\": \"my_app.permissions.project_query\"\n}"
+    },
+    {
+      "code": "has_permission = { ... }",
+      "description": "Defines a custom permission checking logic for a DocType, overriding the standard role-based permissions.",
+      "example": "has_permission = {\n    \"Event\": \"my_app.permissions.event_has_permission\"\n}"
+    },
+    {
+      "code": "app_include_js = 'path' or ['path1', ...]",
+      "description": "Includes custom JavaScript files in the Desk UI.",
+      "example": "app_include_js = \"/assets/my_app/js/custom_script.js\""
+    },
+    {
+      "code": "app_include_css = 'path' or ['path1', ...]",
+      "description": "Includes custom CSS files in the Desk UI.",
+      "example": "app_include_css = \"/assets/my_app/css/custom_styles.css\""
+    },
+    {
+      "code": "fixtures = [ ... ]",
+      "description": "Specifies data records (as JSON files) to be synced to the database during app installation and migration. Useful for seeding default data.",
+      "example": "fixtures = [\n    \"Custom Field\",\n    \"Property Setter\",\n    {\"dt\": \"Role\", \"filters\": [[\"name\", \"in\", [\"Sales Manager\", \"Purchase Manager\"]]]}\n]"
+    },
+    {
+      "code": "override_doctype_class = { ... }",
+      "description": "Extends or overrides the Python controller class of a standard DocType, allowing you to add or modify its methods.",
+      "example": "override_doctype_class = {\n    \"ToDo\": \"my_app.overrides.todo.CustomToDo\"\n}"
+    },
+    {
+      "code": "website_route_rules = [ ... ]",
+      "description": "Maps custom URL routes to specific controller files, enabling clean, dynamic web pages.",
+      "example": "website_route_rules = [\n    {\"from_route\": \"/projects/<project_name>\", \"to_route\": \"my_app.www.project\"}\n]"
+    },
+    {
+      "code": "on_session_creation = 'path.to.method'",
+      "description": "Runs a function every time a new user session is created (i.e., after a successful login).",
+      "example": "on_session_creation = \"my_app.auth.setup_user_session\""
+    },
+    {
+      "code": "user_data_fields = [ ... ]",
+      "description": "Defines which DocTypes and fields contain personal user data, for use with data privacy features like data deletion and export.",
+      "example": "user_data_fields = [\n    {\"doctype\": \"Contact\", \"filter_by\": \"email_id\", \"rename\": True},\n    {\"doctype\": \"User\", \"redact_fields\": [\"first_name\", \"last_name\"]}\n]"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/hooks-py.json
+++ b/data/cheatsheets/hooks-py.json
@@ -1,0 +1,69 @@
+{
+  "title": "Ganchos de Frappe (Python)",
+  "language": "es",
+  "tags": ["python", "hooks", "backend", "personalización"],
+  "items": [
+    {
+      "code": "doc_events = { ... }",
+      "description": "Se engancha a los eventos CRUD (Crear, Leer, Actualizar, Eliminar) de los documentos. Permite ejecutar código personalizado antes o después de acciones como `validate`, `on_submit`, `on_cancel`, etc.",
+      "example": "doc_events = {\n    \"Task\": {\n        \"on_update\": \"mi_app.tasks.on_task_update\"\n    },\n    \"*\": {\n        \"after_insert\": \"mi_app.utils.log_all_inserts\"\n    }\n}"
+    },
+    {
+      "code": "scheduler_events = { ... }",
+      "description": "Programa funciones de Python para que se ejecuten periódicamente en segundo plano. Admite sintaxis cron y preajustes como `hourly`, `daily`, `weekly`, `monthly`.",
+      "example": "scheduler_events = {\n    \"daily\": [\n        \"mi_app.tasks.cleanup_old_logs\"\n    ],\n    \"cron\": {\n        \"*/15 * * * *\": [\n            \"mi_app.tasks.check_system_health\"\n        ]\n    }\n}"
+    },
+    {
+      "code": "override_whitelisted_methods = { ... }",
+      "description": "Reemplaza un método estándar de la lista blanca con tu propia implementación personalizada. Útil para cambiar el comportamiento del API principal.",
+      "example": "override_whitelisted_methods = {\n    \"frappe.client.get_count\": \"mi_app.overrides.custom_get_count\"\n}"
+    },
+    {
+      "code": "permission_query_conditions = { ... }",
+      "description": "Aplica condiciones `WHERE` de SQL adicionales a las consultas de lista (`frappe.db.get_list`), permitiendo una seguridad detallada a nivel de registro basada en el usuario.",
+      "example": "permission_query_conditions = {\n    \"Project\": \"mi_app.permissions.project_query\"\n}"
+    },
+    {
+      "code": "has_permission = { ... }",
+      "description": "Define una lógica de verificación de permisos personalizada para un DocType, anulando los permisos estándar basados en roles.",
+      "example": "has_permission = {\n    \"Event\": \"mi_app.permissions.event_has_permission\"\n}"
+    },
+    {
+      "code": "app_include_js = 'ruta' or ['ruta1', ...]",
+      "description": "Incluye archivos JavaScript personalizados en la interfaz de Desk.",
+      "example": "app_include_js = \"/assets/mi_app/js/custom_script.js\""
+    },
+    {
+      "code": "app_include_css = 'ruta' or ['ruta1', ...]",
+      "description": "Incluye archivos CSS personalizados en la interfaz de Desk.",
+      "example": "app_include_css = \"/assets/mi_app/css/custom_styles.css\""
+    },
+    {
+      "code": "fixtures = [ ... ]",
+      "description": "Especifica registros de datos (como archivos JSON) que se sincronizarán con la base de datos durante la instalación y migración de la aplicación. Útil para sembrar datos predeterminados.",
+      "example": "fixtures = [\n    \"Custom Field\",\n    \"Property Setter\",\n    {\"dt\": \"Role\", \"filters\": [[\"name\", \"in\", [\"Sales Manager\", \"Purchase Manager\"]]]}\n]"
+    },
+    {
+      "code": "override_doctype_class = { ... }",
+      "description": "Extiende o anula la clase del controlador de Python de un DocType estándar, permitiéndote agregar o modificar sus métodos.",
+      "example": "override_doctype_class = {\n    \"ToDo\": \"mi_app.overrides.todo.CustomToDo\"\n}"
+    },
+    {
+      "code": "website_route_rules = [ ... ]",
+      "description": "Mapea rutas de URL personalizadas a archivos de controlador específicos, permitiendo páginas web limpias y dinámicas.",
+      "example": "website_route_rules = [\n    {\"from_route\": \"/projects/<project_name>\", \"to_route\": \"mi_app.www.project\"}\n]"
+    },
+    {
+      "code": "on_session_creation = 'ruta.a.metodo'",
+      "description": "Ejecuta una función cada vez que se crea una nueva sesión de usuario (es decir, después de un inicio de sesión exitoso).",
+      "example": "on_session_creation = \"mi_app.auth.setup_user_session\""
+    },
+    {
+      "code": "user_data_fields = [ ... ]",
+      "description": "Define qué DocTypes y campos contienen datos personales del usuario, para su uso con funciones de privacidad de datos como la eliminación y exportación de datos.",
+      "example": "user_data_fields = [\n    {\"doctype\": \"Contact\", \"filter_by\": \"email_id\", \"rename\": True},\n    {\"doctype\": \"User\", \"redact_fields\": [\"first_name\", \"last_name\"]}\n]"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/jinja-py-en.json
+++ b/data/cheatsheets/jinja-py-en.json
@@ -1,0 +1,64 @@
+{
+  "title": "Jinja API (Python)",
+  "language": "en",
+  "tags": ["python", "jinja", "templating", "backend"],
+  "items": [
+    {
+      "code": "frappe.get_doc(doctype, name)",
+      "description": "Fetches a full document object, which can then be used to access its fields.",
+      "example": "{% set task = frappe.get_doc('Task', 'TASK00001') %}\n<h3>{{ task.subject }}</h3>\n<p>Status: {{ task.status }}</p>"
+    },
+    {
+      "code": "frappe.get_list(doctype, filters, fields)",
+      "description": "Fetches a list of documents, applying user permissions. Similar to `frappe.get_all` but respects permissions.",
+      "example": "{% set open_tasks = frappe.get_list('Task', filters={'status': 'Open'}, fields=['subject']) %}\n<ul>\n    {% for task in open_tasks %}\n        <li>{{ task.subject }}</li>\n    {% endfor %}\n</ul>"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name, fieldname)",
+      "description": "A more efficient way to fetch one or more specific field values from a document without loading the entire object.",
+      "example": "Company Abbreviation: {{ frappe.db.get_value('Company', 'Frappe Inc', 'abbr') }}"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, fieldname)",
+      "description": "Fetches a value from a Single DocType, like System Settings.",
+      "example": "The system timezone is {{ frappe.db.get_single_value('System Settings', 'time_zone') }}."
+    },
+    {
+      "code": "frappe.format(value, df)",
+      "description": "Formats a raw database value into a user-friendly format based on DocField properties (e.g., formatting dates, currencies).",
+      "example": "Formatted Date: {{ frappe.format('2023-10-26', {'fieldtype': 'Date'}) }}"
+    },
+    {
+      "code": "frappe.format_date(date_string)",
+      "description": "Formats a date string into a long, human-readable format (e.g., 'October 26, 2023').",
+      "example": "{{ frappe.format_date(doc.posting_date) }}"
+    },
+    {
+      "code": "_(text) or frappe._(text)",
+      "description": "Translates a string into the current user's language.",
+      "example": "<h1>{{ _('Hello World') }}</h1>"
+    },
+    {
+      "code": "frappe.render_template(template_path, context)",
+      "description": "Renders another Jinja template from a file and includes it in the current template.",
+      "example": "{{ frappe.render_template('templates/includes/my_partial.html', {'my_variable': 'value'}) }}"
+    },
+    {
+      "code": "frappe.session.user",
+      "description": "Returns the email/ID of the currently logged-in user.",
+      "example": "Welcome, {{ frappe.session.user }}!"
+    },
+    {
+      "code": "frappe.form_dict",
+      "description": "A dictionary containing the query parameters of the current web request.",
+      "example": "{% set user_id = frappe.form_dict.get('user') %}"
+    },
+    {
+      "code": "frappe.get_meta(doctype)",
+      "description": "Returns the meta object for a DocType, containing information about its fields, permissions, and properties.",
+      "example": "{% set task_meta = frappe.get_meta('Task') %}\n<p>The Task DocType has {{ task_meta.fields | len }} fields.</p>"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/jinja-py.json
+++ b/data/cheatsheets/jinja-py.json
@@ -1,0 +1,64 @@
+{
+  "title": "API de Jinja (Python)",
+  "language": "es",
+  "tags": ["python", "jinja", "plantillas", "backend"],
+  "items": [
+    {
+      "code": "frappe.get_doc(doctype, name)",
+      "description": "Obtiene un objeto de documento completo, que luego se puede usar para acceder a sus campos.",
+      "example": "{% set task = frappe.get_doc('Task', 'TASK00001') %}\n<h3>{{ task.subject }}</h3>\n<p>Estado: {{ task.status }}</p>"
+    },
+    {
+      "code": "frappe.get_list(doctype, filters, fields)",
+      "description": "Obtiene una lista de documentos, aplicando los permisos del usuario. Similar a `frappe.get_all` pero respeta los permisos.",
+      "example": "{% set open_tasks = frappe.get_list('Task', filters={'status': 'Abierto'}, fields=['subject']) %}\n<ul>\n    {% for task in open_tasks %}\n        <li>{{ task.subject }}</li>\n    {% endfor %}\n</ul>"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name, fieldname)",
+      "description": "Una forma más eficiente de obtener uno o más valores de campos específicos de un documento sin cargar el objeto completo.",
+      "example": "Abreviatura de la Compañía: {{ frappe.db.get_value('Company', 'Frappe Inc', 'abbr') }}"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, fieldname)",
+      "description": "Obtiene un valor de un DocType Single, como Configuraciones del Sistema.",
+      "example": "La zona horaria del sistema es {{ frappe.db.get_single_value('System Settings', 'time_zone') }}."
+    },
+    {
+      "code": "frappe.format(value, df)",
+      "description": "Formatea un valor crudo de la base de datos a un formato amigable para el usuario basado en las propiedades del DocField (p. ej., formateo de fechas, monedas).",
+      "example": "Fecha Formateada: {{ frappe.format('2023-10-26', {'fieldtype': 'Date'}) }}"
+    },
+    {
+      "code": "frappe.format_date(date_string)",
+      "description": "Formatea una cadena de fecha a un formato largo y legible para humanos (p. ej., '26 de octubre de 2023').",
+      "example": "{{ frappe.format_date(doc.posting_date) }}"
+    },
+    {
+      "code": "_(text) or frappe._(text)",
+      "description": "Traduce una cadena de texto al idioma del usuario actual.",
+      "example": "<h1>{{ _('Hola Mundo') }}</h1>"
+    },
+    {
+      "code": "frappe.render_template(template_path, context)",
+      "description": "Renderiza otra plantilla Jinja desde un archivo y la incluye en la plantilla actual.",
+      "example": "{{ frappe.render_template('templates/includes/my_partial.html', {'my_variable': 'valor'}) }}"
+    },
+    {
+      "code": "frappe.session.user",
+      "description": "Devuelve el correo electrónico/ID del usuario actualmente conectado.",
+      "example": "¡Bienvenido, {{ frappe.session.user }}!"
+    },
+    {
+      "code": "frappe.form_dict",
+      "description": "Un diccionario que contiene los parámetros de consulta de la solicitud web actual.",
+      "example": "{% set user_id = frappe.form_dict.get('user') %}"
+    },
+    {
+      "code": "frappe.get_meta(doctype)",
+      "description": "Devuelve el objeto meta para un DocType, que contiene información sobre sus campos, permisos y propiedades.",
+      "example": "{% set task_meta = frappe.get_meta('Task') %}\n<p>El DocType Tarea tiene {{ task_meta.fields | len }} campos.</p>"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/language-resolution-py-en.json
+++ b/data/cheatsheets/language-resolution-py-en.json
@@ -1,0 +1,34 @@
+{
+  "title": "Language Resolution Order (Python)",
+  "language": "en",
+  "tags": ["python", "localization", "language", "backend"],
+  "items": [
+    {
+      "code": "1. Form Dict: `_lang`",
+      "description": "Highest priority. The language is set via the `_lang` parameter in the request's form dictionary (e.g., `?_lang=ru`). This is often used for specific contexts like email templates or print views.",
+      "example": "// A request to /api/resource/Task?_lang=es will force the session language to Spanish for that request."
+    },
+    {
+      "code": "2. Cookie: `preferred_language` (Guest Users)",
+      "description": "For guest (not logged-in) users, a cookie named `preferred_language` can set a persistent but temporary language preference. This is used by the website language switcher.",
+      "example": "// If a guest user selects 'German' from a language switcher, a cookie `preferred_language=de` is set."
+    },
+    {
+      "code": "3. Request Header: `Accept-Language` (Guest Users)",
+      "description": "For guest users, if no cookie is set, Frappe will check the standard `Accept-Language` HTTP header sent by the browser to determine the user's preferred language.",
+      "example": "// Browser sends `Accept-Language: fr-CH, fr;q=0.9, en;q=0.8`. Frappe would resolve to French."
+    },
+    {
+      "code": "4. User Document: `language`",
+      "description": "For logged-in users, the `language` field in their User document takes precedence. This setting persists across all devices and sessions for that user.",
+      "example": "// The User 'test@example.com' has their language field set to 'Spanish' in their User document."
+    },
+    {
+      "code": "5. System Settings: `language`",
+      "description": "Lowest priority. The `language` field in System Settings serves as the default, site-wide fallback language if no other language is determined by the methods above.",
+      "example": "// System Settings has 'English' set as the default language for the entire site."
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/language-resolution-py.json
+++ b/data/cheatsheets/language-resolution-py.json
@@ -1,0 +1,34 @@
+{
+  "title": "Orden de Resolución de Idioma (Python)",
+  "language": "es",
+  "tags": ["python", "localización", "idioma", "backend"],
+  "items": [
+    {
+      "code": "1. Diccionario de Formulario: `_lang`",
+      "description": "Prioridad más alta. El idioma se establece a través del parámetro `_lang` en el diccionario de formulario de la solicitud (p. ej., `?_lang=ru`). Se usa a menudo para contextos específicos como plantillas de correo electrónico o vistas de impresión.",
+      "example": "// Una solicitud a /api/resource/Task?_lang=es forzará el idioma de la sesión a español para esa solicitud."
+    },
+    {
+      "code": "2. Cookie: `preferred_language` (Usuarios Invitados)",
+      "description": "Para usuarios invitados (no autenticados), una cookie llamada `preferred_language` puede establecer una preferencia de idioma persistente pero temporal. Esto es utilizado por el selector de idioma del sitio web.",
+      "example": "// Si un usuario invitado selecciona 'Alemán' en un selector de idioma, se establece una cookie `preferred_language=de`."
+    },
+    {
+      "code": "3. Cabecera de Solicitud: `Accept-Language` (Usuarios Invitados)",
+      "description": "Para usuarios invitados, si no se establece ninguna cookie, Frappe verificará la cabecera HTTP estándar `Accept-Language` enviada por el navegador para determinar el idioma preferido del usuario.",
+      "example": "// El navegador envía `Accept-Language: fr-CH, fr;q=0.9, en;q=0.8`. Frappe resolvería a francés."
+    },
+    {
+      "code": "4. Documento de Usuario: `language`",
+      "description": "Para usuarios autenticados, el campo `language` en su documento de Usuario tiene precedencia. Esta configuración persiste en todos los dispositivos y sesiones para ese usuario.",
+      "example": "// El Usuario 'test@example.com' tiene su campo de idioma establecido en 'Español' en su documento de Usuario."
+    },
+    {
+      "code": "5. Configuraciones del Sistema: `language`",
+      "description": "Prioridad más baja. El campo `language` en Configuraciones del Sistema sirve como el idioma de respaldo predeterminado para todo el sitio si no se determina ningún otro idioma por los métodos anteriores.",
+      "example": "// Configuraciones del Sistema tiene 'Inglés' establecido como el idioma predeterminado para todo el sitio."
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/list-view-en.json
+++ b/data/cheatsheets/list-view-en.json
@@ -1,0 +1,54 @@
+{
+  "title": "List View Settings",
+  "language": "en",
+  "tags": ["javascript", "list-view", "api"],
+  "items": [
+    {
+      "code": "frappe.listview_settings['DocType'] = { ... }",
+      "description": "To customize the List View for a DocType, you create a `{doctype}_list.js` file and define the settings within this structure.",
+      "example": "frappe.listview_settings['Note'] = {\n    // settings go here\n};"
+    },
+    {
+      "code": "add_fields: ['field1', 'field2']",
+      "description": "An array of field names to be fetched in addition to the standard list fields. These can be used in formatters or other custom logic.",
+      "example": "add_fields: ['title', 'public']"
+    },
+    {
+      "code": "filters: [['field', 'operator', 'value']]",
+      "description": "An array of filters to be applied by default when the list view is loaded.",
+      "example": "filters: [\n    ['public', '=', 1]\n]"
+    },
+    {
+      "code": "hide_name_column: true",
+      "description": "A boolean to hide the last column in the list view, which typically shows the document's unique name.",
+      "example": "hide_name_column: true"
+    },
+    {
+      "code": "onload(listview) { ... }",
+      "description": "A function that is triggered once, just before the list view is loaded for the first time.",
+      "example": "onload(listview) {\n    console.log('List view is loading.');\n}"
+    },
+    {
+      "code": "get_indicator(doc) { ... }",
+      "description": "A function that returns an array to display a colored indicator for each row. The array format is [Label, Color, Filter_Condition].",
+      "example": "get_indicator(doc) {\n    if (doc.public) {\n        return [__(\"Public\"), \"green\", \"public,=,Yes\"];\n    } else {\n        return [__(\"Private\"), \"darkgrey\", \"public,=,No\"];\n    }\n}"
+    },
+    {
+      "code": "primary_action() { ... }",
+      "description": "A function that is triggered when the primary action button (usually 'New') is clicked.",
+      "example": "primary_action() {\n    frappe.new_doc('Note');\n}"
+    },
+    {
+      "code": "button: { show(doc), get_label(), get_description(doc), action(doc) }",
+      "description": "An object that defines a custom button to be displayed on each row of the list view.",
+      "example": "button: {\n    show(doc) {\n        return doc.reference_name;\n    },\n    get_label() {\n        return 'View Reference';\n    },\n    action(doc) {\n        frappe.set_route('Form', doc.reference_type, doc.reference_name);\n    }\n}"
+    },
+    {
+      "code": "formatters: { fieldname(val) { ... } }",
+      "description": "An object containing functions to format the display of specific field values in the list view.",
+      "example": "formatters: {\n    title(val) {\n        return val.bold();\n    },\n    public(val) {\n        return val ? 'Yes' : 'No';\n    }\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/list-view.json
+++ b/data/cheatsheets/list-view.json
@@ -1,0 +1,54 @@
+{
+  "title": "Configuración de Vista de Lista",
+  "language": "es",
+  "tags": ["javascript", "vista-de-lista", "api"],
+  "items": [
+    {
+      "code": "frappe.listview_settings['DocType'] = { ... }",
+      "description": "Para personalizar la Vista de Lista para un DocType, creas un archivo `{doctype}_list.js` y defines la configuración dentro de esta estructura.",
+      "example": "frappe.listview_settings['Note'] = {\n    // la configuración va aquí\n};"
+    },
+    {
+      "code": "add_fields: ['campo1', 'campo2']",
+      "description": "Un array de nombres de campos a obtener además de los campos de lista estándar. Estos pueden ser usados en formateadores u otra lógica personalizada.",
+      "example": "add_fields: ['title', 'public']"
+    },
+    {
+      "code": "filters: [['campo', 'operador', 'valor']]",
+      "description": "Un array de filtros que se aplicarán por defecto cuando se cargue la vista de lista.",
+      "example": "filters: [\n    ['public', '=', 1]\n]"
+    },
+    {
+      "code": "hide_name_column: true",
+      "description": "Un booleano para ocultar la última columna en la vista de lista, que típicamente muestra el nombre único del documento.",
+      "example": "hide_name_column: true"
+    },
+    {
+      "code": "onload(listview) { ... }",
+      "description": "Una función que se dispara una vez, justo antes de que la vista de lista se cargue por primera vez.",
+      "example": "onload(listview) {\n    console.log('La vista de lista se está cargando.');\n}"
+    },
+    {
+      "code": "get_indicator(doc) { ... }",
+      "description": "Una función que devuelve un array para mostrar un indicador de color para cada fila. El formato del array es [Etiqueta, Color, Condición_Filtro].",
+      "example": "get_indicator(doc) {\n    if (doc.public) {\n        return [__(\"Público\"), \"green\", \"public,=,Yes\"];\n    } else {\n        return [__(\"Privado\"), \"darkgrey\", \"public,=,No\"];\n    }\n}"
+    },
+    {
+      "code": "primary_action() { ... }",
+      "description": "Una función que se dispara cuando se hace clic en el botón de acción principal (generalmente 'Nuevo').",
+      "example": "primary_action() {\n    frappe.new_doc('Note');\n}"
+    },
+    {
+      "code": "button: { show(doc), get_label(), get_description(doc), action(doc) }",
+      "description": "Un objeto que define un botón personalizado que se mostrará en cada fila de la vista de lista.",
+      "example": "button: {\n    show(doc) {\n        return doc.reference_name;\n    },\n    get_label() {\n        return 'Ver Referencia';\n    },\n    action(doc) {\n        frappe.set_route('Form', doc.reference_type, doc.reference_name);\n    }\n}"
+    },
+    {
+      "code": "formatters: { fieldname(val) { ... } }",
+      "description": "Un objeto que contiene funciones para formatear la visualización de valores de campos específicos en la vista de lista.",
+      "example": "formatters: {\n    title(val) {\n        return val.bold();\n    },\n    public(val) {\n        return val ? 'Sí' : 'No';\n    }\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/logging-py-en.json
+++ b/data/cheatsheets/logging-py-en.json
@@ -1,0 +1,44 @@
+{
+  "title": "Logging API (Python)",
+  "language": "en",
+  "tags": ["python", "logging", "api", "backend"],
+  "items": [
+    {
+      "code": "frappe.logger(module, ...)",
+      "description": "Returns a logging.Logger object for both site and bench level logging. If the logger doesn't exist, it is created.",
+      "example": "frappe.utils.logger.set_log_level(\"DEBUG\")\nlogger = frappe.logger(\"api\", allow_site=True, file_count=50)"
+    },
+    {
+      "code": "logger.info(message)",
+      "description": "Logs a message with the level 'INFO'. Useful for tracking normal application events.",
+      "example": "user = frappe.session.user\nlogger.info(f\"{user} accessed counter_app.update with value={value}\")"
+    },
+    {
+      "code": "logger.debug(message)",
+      "description": "Logs a message with the level 'DEBUG'. Useful for detailed information, typically during development and troubleshooting.",
+      "example": "logger.debug(f\"{current_value} + {value} = {updated_value}\")"
+    },
+    {
+      "code": "logger.warning(message)",
+      "description": "Logs a message with the level 'WARNING'. Indicates a potential issue that doesn't prevent the program from running.",
+      "example": "logger.warning('The session will expire soon.')"
+    },
+    {
+      "code": "logger.error(message)",
+      "description": "Logs a message with the level 'ERROR'. Records a serious error that has occurred.",
+      "example": "logger.error('Failed to connect to the database.')"
+    },
+    {
+      "code": "logger.critical(message)",
+      "description": "Logs a message with the level 'CRITICAL'. Records a critical error that might lead to the application terminating.",
+      "example": "logger.critical('System shutdown due to critical failure.')"
+    },
+    {
+      "code": "frappe.utils.logger.set_log_level(level)",
+      "description": "Sets the logging level dynamically for Frappe processes. Levels include 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'.",
+      "example": "frappe.utils.logger.set_log_level(\"INFO\")"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/logging-py.json
+++ b/data/cheatsheets/logging-py.json
@@ -1,0 +1,44 @@
+{
+  "title": "API de Logging (Python)",
+  "language": "es",
+  "tags": ["python", "logging", "api", "backend"],
+  "items": [
+    {
+      "code": "frappe.logger(module, ...)",
+      "description": "Devuelve un objeto logging.Logger para el registro a nivel de sitio y de bench. Si el logger no existe, se crea.",
+      "example": "frappe.utils.logger.set_log_level(\"DEBUG\")\nlogger = frappe.logger(\"api\", allow_site=True, file_count=50)"
+    },
+    {
+      "code": "logger.info(message)",
+      "description": "Registra un mensaje con el nivel 'INFO'. Útil para rastrear eventos normales de la aplicación.",
+      "example": "user = frappe.session.user\nlogger.info(f\"{user} accedió a counter_app.update con valor={value}\")"
+    },
+    {
+      "code": "logger.debug(message)",
+      "description": "Registra un mensaje con el nivel 'DEBUG'. Útil para información detallada, típicamente durante el desarrollo y la solución de problemas.",
+      "example": "logger.debug(f\"{current_value} + {value} = {updated_value}\")"
+    },
+    {
+      "code": "logger.warning(message)",
+      "description": "Registra un mensaje con el nivel 'WARNING'. Indica un problema potencial que no impide que el programa se ejecute.",
+      "example": "logger.warning('La sesión expirará pronto.')"
+    },
+    {
+      "code": "logger.error(message)",
+      "description": "Registra un mensaje con el nivel 'ERROR'. Registra un error grave que ha ocurrido.",
+      "example": "logger.error('Fallo al conectar con la base de datos.')"
+    },
+    {
+      "code": "logger.critical(message)",
+      "description": "Registra un mensaje con el nivel 'CRITICAL'. Registra un error crítico que podría llevar a la terminación de la aplicación.",
+      "example": "logger.critical('Apagado del sistema debido a un fallo crítico.')"
+    },
+    {
+      "code": "frappe.utils.logger.set_log_level(level)",
+      "description": "Establece el nivel de registro dinámicamente para los procesos de Frappe. Los niveles incluyen 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'.",
+      "example": "frappe.utils.logger.set_log_level(\"INFO\")"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/page-api-en.json
+++ b/data/cheatsheets/page-api-en.json
@@ -1,0 +1,69 @@
+{
+  "title": "Page API",
+  "language": "en",
+  "tags": ["javascript", "ui", "page", "api"],
+  "items": [
+    {
+      "code": "frappe.ui.make_app_page({ title, parent, single_column })",
+      "description": "Creates a new Page object and attaches it to a parent DOM element.",
+      "example": "let page = frappe.ui.make_app_page({\n    title: 'My Page',\n    parent: wrapper,\n    single_column: true\n});"
+    },
+    {
+      "code": "page.set_title(title)",
+      "description": "Sets the main title of the page, which is also reflected in the browser tab.",
+      "example": "page.set_title('My Awesome Page');"
+    },
+    {
+      "code": "page.set_title_sub(subtitle)",
+      "description": "Sets the secondary title (subtitle) of the page, shown on the right side of the header.",
+      "example": "page.set_title_sub('Subtitle');"
+    },
+    {
+      "code": "page.set_indicator(label, color)",
+      "description": "Sets a status indicator with a specific label and color (e.g., 'orange', 'green', 'red').",
+      "example": "page.set_indicator('Pending', 'orange');"
+    },
+    {
+      "code": "page.set_primary_action(label, handler, icon)",
+      "description": "Sets the primary action button (the main blue button) with a label, handler function, and an optional icon.",
+      "example": "page.set_primary_action('New', () => create_new(), 'octicon octicon-plus');"
+    },
+    {
+      "code": "page.set_secondary_action(label, handler, icon)",
+      "description": "Sets the secondary action button (the grey button) with a label, handler, and optional icon.",
+      "example": "page.set_secondary_action('Refresh', () => refresh(), 'octicon octicon-sync');"
+    },
+    {
+      "code": "page.add_menu_item(label, handler, is_standard)",
+      "description": "Adds an item to the 'Menu' dropdown in the page header.",
+      "example": "page.add_menu_item('Send Email', () => open_email_dialog());"
+    },
+    {
+      "code": "page.add_action_item(label, handler)",
+      "description": "Adds an item to the 'Actions' dropdown in the page header.",
+      "example": "page.add_action_item('Delete', () => delete_items());"
+    },
+    {
+      "code": "page.add_inner_button(label, handler, group)",
+      "description": "Adds a button to the inner toolbar of the page. Can be grouped into a dropdown.",
+      "example": "// Add a standalone button\npage.add_inner_button('Update Posts', () => update_posts());\n\n// Add a button within a group\npage.add_inner_button('New Post', () => new_post(), 'Make');"
+    },
+    {
+      "code": "page.add_field({ label, fieldtype, ... })",
+      "description": "Adds a form control (field) to the page's header toolbar.",
+      "example": "let field = page.add_field({\n    label: 'Status',\n    fieldtype: 'Select',\n    fieldname: 'status',\n    options: ['Open', 'Closed'],\n    change() {\n        console.log(field.get_value());\n    }\n});"
+    },
+    {
+      "code": "page.get_form_values()",
+      "description": "Returns an object containing the current values of all fields in the page's header toolbar.",
+      "example": "let values = page.get_form_values();\n// { status: 'Open' }"
+    },
+    {
+      "code": "page.clear_fields()",
+      "description": "Removes all fields from the page's header toolbar.",
+      "example": "page.clear_fields();"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/page-api.json
+++ b/data/cheatsheets/page-api.json
@@ -1,0 +1,69 @@
+{
+  "title": "API de Página",
+  "language": "es",
+  "tags": ["javascript", "ui", "página", "api"],
+  "items": [
+    {
+      "code": "frappe.ui.make_app_page({ title, parent, single_column })",
+      "description": "Crea un nuevo objeto Página y lo adjunta a un elemento DOM padre.",
+      "example": "let page = frappe.ui.make_app_page({\n    title: 'Mi Página',\n    parent: wrapper,\n    single_column: true\n});"
+    },
+    {
+      "code": "page.set_title(title)",
+      "description": "Establece el título principal de la página, que también se refleja en la pestaña del navegador.",
+      "example": "page.set_title('Mi Página Increíble');"
+    },
+    {
+      "code": "page.set_title_sub(subtitle)",
+      "description": "Establece el título secundario (subtítulo) de la página, que se muestra en el lado derecho del encabezado.",
+      "example": "page.set_title_sub('Subtítulo');"
+    },
+    {
+      "code": "page.set_indicator(label, color)",
+      "description": "Establece un indicador de estado con una etiqueta y color específicos (p. ej., 'orange', 'green', 'red').",
+      "example": "page.set_indicator('Pendiente', 'orange');"
+    },
+    {
+      "code": "page.set_primary_action(label, handler, icon)",
+      "description": "Establece el botón de acción principal (el botón azul principal) con una etiqueta, una función de manejador y un ícono opcional.",
+      "example": "page.set_primary_action('Nuevo', () => create_new(), 'octicon octicon-plus');"
+    },
+    {
+      "code": "page.set_secondary_action(label, handler, icon)",
+      "description": "Establece el botón de acción secundario (el botón gris) con una etiqueta, un manejador y un ícono opcional.",
+      "example": "page.set_secondary_action('Refrescar', () => refresh(), 'octicon octicon-sync');"
+    },
+    {
+      "code": "page.add_menu_item(label, handler, is_standard)",
+      "description": "Agrega un elemento al menú desplegable 'Menú' en el encabezado de la página.",
+      "example": "page.add_menu_item('Enviar Correo', () => open_email_dialog());"
+    },
+    {
+      "code": "page.add_action_item(label, handler)",
+      "description": "Agrega un elemento al menú desplegable 'Acciones' en el encabezado de la página.",
+      "example": "page.add_action_item('Eliminar', () => delete_items());"
+    },
+    {
+      "code": "page.add_inner_button(label, handler, group)",
+      "description": "Agrega un botón a la barra de herramientas interna de la página. Se puede agrupar en un menú desplegable.",
+      "example": "// Agregar un botón independiente\npage.add_inner_button('Actualizar Posts', () => update_posts());\n\n// Agregar un botón dentro de un grupo\npage.add_inner_button('Nuevo Post', () => new_post(), 'Crear');"
+    },
+    {
+      "code": "page.add_field({ label, fieldtype, ... })",
+      "description": "Agrega un control de formulario (campo) a la barra de herramientas del encabezado de la página.",
+      "example": "let field = page.add_field({\n    label: 'Estado',\n    fieldtype: 'Select',\n    fieldname: 'status',\n    options: ['Abierto', 'Cerrado'],\n    change() {\n        console.log(field.get_value());\n    }\n});"
+    },
+    {
+      "code": "page.get_form_values()",
+      "description": "Devuelve un objeto que contiene los valores actuales de todos los campos en la barra de herramientas del encabezado de la página.",
+      "example": "let values = page.get_form_values();\n// { status: 'Abierto' }"
+    },
+    {
+      "code": "page.clear_fields()",
+      "description": "Elimina todos los campos de la barra de herramientas del encabezado de la página.",
+      "example": "page.clear_fields();"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/query-builder-py-en.json
+++ b/data/cheatsheets/query-builder-py-en.json
@@ -1,0 +1,54 @@
+{
+  "title": "Query Builder API (Python)",
+  "language": "en",
+  "tags": ["python", "database", "query-builder", "orm", "backend"],
+  "items": [
+    {
+      "code": "from frappe.query_builder import DocType",
+      "description": "The first step is to import the `DocType` object and use it to create a reference to the database table you want to query.",
+      "example": "from frappe.query_builder import DocType\nTask = DocType('Task')"
+    },
+    {
+      "code": "frappe.qb.from_(MyDocType).select(...).run()",
+      "description": "The basic structure of a query. Start with `frappe.qb.from_`, select the desired fields, and execute it with `.run()`.",
+      "example": "Task = DocType('Task')\nquery = frappe.qb.from_(Task).select(Task.name, Task.subject, Task.status)\ntasks = query.run(as_dict=True)"
+    },
+    {
+      "code": ".where(condition)",
+      "description": "Filters the query results based on one or more conditions. You can chain multiple `.where()` calls, which are combined with `AND`.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .where(Task.status == 'Open')\n    .where(Task.priority == 'High')\n)\n"
+    },
+    {
+      "code": "Complex .where() conditions (AND/OR)",
+      "description": "Use `&` for `AND` and `|` for `OR` to combine multiple conditions within a single `.where()` clause.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .where((Task.status == 'Open') | (Task.priority == 'Urgent'))\n)"
+    },
+    {
+      "code": ".join(OtherDocType).on(condition)",
+      "description": "Joins the query with another table. Use `.on()` to specify the join condition.",
+      "example": "User = DocType('User')\nToDo = DocType('ToDo')\nquery = (\n    frappe.qb.from_(ToDo)\n    .join(User).on(User.name == ToDo.owner)\n    .select(ToDo.description, User.full_name)\n)"
+    },
+    {
+      "code": "from frappe.query_builder.functions import Count, Sum, Avg",
+      "description": "Use aggregate functions like `Count`, `Sum`, `Avg`, etc., to perform calculations on your data. Use `.as_('alias')` to name the resulting column.",
+      "example": "from frappe.query_builder.functions import Count\n\nTask = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.status, Count('*').as_('count'))\n    .groupby(Task.status)\n)\nresults = query.run(as_dict=True)"
+    },
+    {
+      "code": ".orderby(field, order=Order.asc)",
+      "description": "Sorts the results. `Order` can be imported from `pypika.enums`.",
+      "example": "from pypika.enums import Order\n\nTask = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject, Task.creation)\n    .orderby(Task.creation, order=Order.desc)\n)"
+    },
+    {
+      "code": ".limit(n).offset(m)",
+      "description": "Used for pagination. `.limit()` specifies the number of records to return, and `.offset()` specifies the starting point.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .limit(10).offset(20) # Get records 21-30\n)"
+    },
+    {
+      "code": "query.run(as_dict=True, debug=False)",
+      "description": "Executes the query. `as_dict=True` returns a list of dictionaries instead of a list of tuples. `debug=True` prints the SQL query and execution time.",
+      "example": "Task = DocType('Task')\nresults = frappe.qb.from_(Task).select(Task.name).run(as_dict=True, debug=True)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/query-builder-py.json
+++ b/data/cheatsheets/query-builder-py.json
@@ -1,0 +1,54 @@
+{
+  "title": "API del Constructor de Consultas (Python)",
+  "language": "es",
+  "tags": ["python", "database", "query-builder", "orm", "backend"],
+  "items": [
+    {
+      "code": "from frappe.query_builder import DocType",
+      "description": "El primer paso es importar el objeto `DocType` y usarlo para crear una referencia a la tabla de la base de datos que deseas consultar.",
+      "example": "from frappe.query_builder import DocType\nTask = DocType('Task')"
+    },
+    {
+      "code": "frappe.qb.from_(MiDocType).select(...).run()",
+      "description": "La estructura básica de una consulta. Comienza con `frappe.qb.from_`, selecciona los campos deseados y ejecútala con `.run()`.",
+      "example": "Task = DocType('Task')\nquery = frappe.qb.from_(Task).select(Task.name, Task.subject, Task.status)\ntasks = query.run(as_dict=True)"
+    },
+    {
+      "code": ".where(condicion)",
+      "description": "Filtra los resultados de la consulta basándose en una o más condiciones. Puedes encadenar múltiples llamadas a `.where()`, que se combinan con `AND`.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .where(Task.status == 'Abierto')\n    .where(Task.priority == 'Alto')\n)\n"
+    },
+    {
+      "code": "Condiciones .where() complejas (AND/OR)",
+      "description": "Usa `&` para `AND` y `|` para `OR` para combinar múltiples condiciones dentro de una sola cláusula `.where()`.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .where((Task.status == 'Abierto') | (Task.priority == 'Urgente'))\n)"
+    },
+    {
+      "code": ".join(OtroDocType).on(condicion)",
+      "description": "Une la consulta con otra tabla. Usa `.on()` para especificar la condición de unión.",
+      "example": "User = DocType('User')\nToDo = DocType('ToDo')\nquery = (\n    frappe.qb.from_(ToDo)\n    .join(User).on(User.name == ToDo.owner)\n    .select(ToDo.description, User.full_name)\n)"
+    },
+    {
+      "code": "from frappe.query_builder.functions import Count, Sum, Avg",
+      "description": "Usa funciones de agregación como `Count`, `Sum`, `Avg`, etc., para realizar cálculos sobre tus datos. Usa `.as_('alias')` para nombrar la columna resultante.",
+      "example": "from frappe.query_builder.functions import Count\n\nTask = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.status, Count('*').as_('count'))\n    .groupby(Task.status)\n)\nresults = query.run(as_dict=True)"
+    },
+    {
+      "code": ".orderby(campo, order=Order.asc)",
+      "description": "Ordena los resultados. `Order` se puede importar desde `pypika.enums`.",
+      "example": "from pypika.enums import Order\n\nTask = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject, Task.creation)\n    .orderby(Task.creation, order=Order.desc)\n)"
+    },
+    {
+      "code": ".limit(n).offset(m)",
+      "description": "Se utiliza para la paginación. `.limit()` especifica el número de registros a devolver, y `.offset()` especifica el punto de inicio.",
+      "example": "Task = DocType('Task')\nquery = (\n    frappe.qb.from_(Task)\n    .select(Task.subject)\n    .limit(10).offset(20) # Obtener registros 21-30\n)"
+    },
+    {
+      "code": "query.run(as_dict=True, debug=False)",
+      "description": "Ejecuta la consulta. `as_dict=True` devuelve una lista de diccionarios en lugar de una lista de tuplas. `debug=True` imprime la consulta SQL y el tiempo de ejecución.",
+      "example": "Task = DocType('Task')\nresults = frappe.qb.from_(Task).select(Task.name).run(as_dict=True, debug=True)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/request-lifecycle-py-en.json
+++ b/data/cheatsheets/request-lifecycle-py-en.json
@@ -1,0 +1,34 @@
+{
+  "title": "Request Lifecycle (Python)",
+  "language": "en",
+  "tags": ["python", "web", "routing", "backend"],
+  "items": [
+    {
+      "code": "Request Handling Order",
+      "description": "Frappe handles incoming web requests in a specific order: API requests (`/api/...`), file downloads (`/files/...`), and finally, web page requests which are passed to the website router.",
+      "example": "1. API Request (`/api/resource/Task`)\n2. File Download (`/private/files/backup.zip`)\n3. Web Page (`/about`)"
+    },
+    {
+      "code": "Path Resolver",
+      "description": "Before rendering, the path resolver determines the final endpoint. It first checks for redirects (from `website_redirects` hook) and then resolves the route using rules (from `website_route_rules` hook or DocTypes with 'Has Web View').",
+      "example": "// A request to '/p/my-product' might be resolved by a website_route_rule to the template 'my_app.www.product.html'."
+    },
+    {
+      "code": "Page Renderer Selection",
+      "description": "After the path is resolved, Frappe selects a renderer to generate the HTML. It checks each available renderer's `.can_render()` method and uses the first one that returns `True`.",
+      "example": "// A request for '/about.html' would be handled by the TemplatePage renderer."
+    },
+    {
+      "code": "Standard Page Renderers",
+      "description": "Frappe includes several standard renderers for common page types.",
+      "example": "/*\n- StaticPage: Serves non-template files like images or PDFs from a `www` folder.\n- TemplatePage: Renders `.html` or `.md` files from a `www` folder.\n- WebformPage: Renders standard Web Forms.\n- DocumentPage: Renders a specific template for a single document view (e.g., `templates/user.html`).\n- ListPage: Renders a template for a document list view.\n- NotFoundPage: Renders the 404 page.\n*/"
+    },
+    {
+      "code": "Custom Page Renderer",
+      "description": "You can create a custom page renderer by defining a class with `can_render()` and `render()` methods and adding it to the `page_renderer` hook in your app.",
+      "example": "# hooks.py\npage_renderer = \"my_app.renderers.CustomRenderer\"\n\n# my_app/renderers.py\nclass CustomRenderer(BaseRenderer):\n    def can_render(self):\n        return self.path == '/my-custom-route'\n    def render(self):\n        return self.build_response('<h1>Custom Page</h1>')"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/request-lifecycle-py.json
+++ b/data/cheatsheets/request-lifecycle-py.json
@@ -1,0 +1,34 @@
+{
+  "title": "Ciclo de Vida de la Solicitud (Python)",
+  "language": "es",
+  "tags": ["python", "web", "enrutamiento", "backend"],
+  "items": [
+    {
+      "code": "Orden de Manejo de Solicitudes",
+      "description": "Frappe maneja las solicitudes web entrantes en un orden específico: solicitudes de API (`/api/...`), descargas de archivos (`/files/...`), y finalmente, solicitudes de páginas web que se pasan al enrutador del sitio web.",
+      "example": "1. Solicitud de API (`/api/resource/Task`)\n2. Descarga de Archivo (`/private/files/backup.zip`)\n3. Página Web (`/about`)"
+    },
+    {
+      "code": "Resolvedor de Rutas (Path Resolver)",
+      "description": "Antes de renderizar, el resolvedor de rutas determina el punto final. Primero verifica si hay redirecciones (del hook `website_redirects`) y luego resuelve la ruta usando reglas (del hook `website_route_rules` o de DocTypes con 'Tiene Vista Web' habilitado).",
+      "example": "// Una solicitud a '/p/mi-producto' podría ser resuelta por una `website_route_rule` a la plantilla 'mi_app.www.producto.html'."
+    },
+    {
+      "code": "Selección del Renderizador de Página",
+      "description": "Después de resolver la ruta, Frappe selecciona un renderizador para generar el HTML. Comprueba el método `.can_render()` de cada renderizador disponible y usa el primero que devuelve `True`.",
+      "example": "// Una solicitud para '/about.html' sería manejada por el renderizador TemplatePage."
+    },
+    {
+      "code": "Renderizadores de Página Estándar",
+      "description": "Frappe incluye varios renderizadores estándar para tipos de página comunes.",
+      "example": "/*\n- StaticPage: Sirve archivos que no son plantillas, como imágenes o PDFs, desde una carpeta `www`.\n- TemplatePage: Renderiza archivos `.html` o `.md` desde una carpeta `www`.\n- WebformPage: Renderiza Formularios Web estándar.\n- DocumentPage: Renderiza una plantilla específica para la vista de un solo documento (ej. `templates/user.html`).\n- ListPage: Renderiza una plantilla para una vista de lista de documentos.\n- NotFoundPage: Renderiza la página 404.\n*/"
+    },
+    {
+      "code": "Renderizador de Página Personalizado",
+      "description": "Puedes crear un renderizador de página personalizado definiendo una clase con los métodos `can_render()` y `render()` y agregándola al hook `page_renderer` en tu aplicación.",
+      "example": "# hooks.py\npage_renderer = \"mi_app.renderers.CustomRenderer\"\n\n# mi_app/renderers.py\nclass CustomRenderer(BaseRenderer):\n    def can_render(self):\n        return self.path == '/mi-ruta-personalizada'\n    def render(self):\n        return self.build_response('<h1>Página Personalizada</h1>')"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/responses-py-en.json
+++ b/data/cheatsheets/responses-py-en.json
@@ -1,0 +1,39 @@
+{
+  "title": "Building Responses (Python)",
+  "language": "en",
+  "tags": ["python", "response", "http", "backend"],
+  "items": [
+    {
+      "code": "The `frappe.response` Dictionary",
+      "description": "Within a whitelisted method, you can build a custom HTTP response by setting values in the global `frappe.response` dictionary. The `type` key determines how the response is constructed.",
+      "example": "# In a @frappe.whitelist() method:\nfrappe.response['type'] = 'download'\nfrappe.response['filename'] = 'report.csv'\n# ... and other keys"
+    },
+    {
+      "code": "File Download (`type: 'download'`)",
+      "description": "To send a file for the user to download, set the response type to 'download' and provide the filename and content.",
+      "example": "@frappe.whitelist()\ndef generate_and_download_file():\n    file_content = 'this,is,a,csv\\n1,2,3,4'\n    frappe.response.type = 'download'\n    frappe.response.filename = 'my_report.csv'\n    frappe.response.filecontent = file_content\n    # Use 'attachment' to force download, 'inline' to display in browser if possible.\n    frappe.response.display_content_as = 'attachment'"
+    },
+    {
+      "code": "JSON Response (Default)",
+      "description": "By default, the `frappe.response` dictionary is sent as a JSON response. This is the standard for most API calls made via `frappe.call`.",
+      "example": "@frappe.whitelist()\ndef get_user_data(user_id):\n    user = frappe.get_doc('User', user_id)\n    # These keys will be in the final JSON response\n    frappe.response['full_name'] = user.full_name\n    frappe.response['email'] = user.email"
+    },
+    {
+      "code": "PDF Response (`type: 'pdf'`)",
+      "description": "To send a generated PDF file. You must provide the PDF file content.",
+      "example": "@frappe.whitelist()\ndef get_invoice_pdf(invoice_id):\n    pdf_content = get_pdf_from_html(...)\n    frappe.response.type = 'pdf'\n    frappe.response.filename = f'{invoice_id}.pdf'\n    frappe.response.filecontent = pdf_content"
+    },
+    {
+      "code": "Redirect (`type: 'redirect'`)",
+      "description": "To perform a server-side redirect, set the type to 'redirect' and provide the target location.",
+      "example": "@frappe.whitelist()\ndef old_url_handler():\n    frappe.response.type = 'redirect'\n    frappe.response.location = '/new-page'"
+    },
+    {
+      "code": "Plain Text (`type: 'txt'`)",
+      "description": "To send a raw, plain text response.",
+      "example": "@frappe.whitelist()\ndef get_raw_log():\n    # This is a simplified example\n    frappe.response.type = 'txt'\n    frappe.response.data = 'LOG: System started successfully.'"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/responses-py.json
+++ b/data/cheatsheets/responses-py.json
@@ -1,0 +1,39 @@
+{
+  "title": "Construcción de Respuestas (Python)",
+  "language": "es",
+  "tags": ["python", "response", "http", "backend"],
+  "items": [
+    {
+      "code": "El Diccionario `frappe.response`",
+      "description": "Dentro de un método en la lista blanca (whitelist), puedes construir una respuesta HTTP personalizada estableciendo valores en el diccionario global `frappe.response`. La clave `type` determina cómo se construye la respuesta.",
+      "example": "# En un método @frappe.whitelist():\nfrappe.response['type'] = 'download'\nfrappe.response['filename'] = 'reporte.csv'\n# ... y otras claves"
+    },
+    {
+      "code": "Descarga de Archivo (`type: 'download'`)",
+      "description": "Para enviar un archivo que el usuario pueda descargar, establece el tipo de respuesta a 'download' y proporciona el nombre del archivo y el contenido.",
+      "example": "@frappe.whitelist()\ndef generate_and_download_file():\n    file_content = 'esto,es,un,csv\\n1,2,3,4'\n    frappe.response.type = 'download'\n    frappe.response.filename = 'mi_reporte.csv'\n    frappe.response.filecontent = file_content\n    # Usa 'attachment' para forzar la descarga, 'inline' para mostrar en el navegador si es posible.\n    frappe.response.display_content_as = 'attachment'"
+    },
+    {
+      "code": "Respuesta JSON (Predeterminada)",
+      "description": "Por defecto, el diccionario `frappe.response` se envía como una respuesta JSON. Este es el estándar para la mayoría de las llamadas a la API realizadas a través de `frappe.call`.",
+      "example": "@frappe.whitelist()\ndef get_user_data(user_id):\n    user = frappe.get_doc('User', user_id)\n    # Estas claves estarán en la respuesta JSON final\n    frappe.response['full_name'] = user.full_name\n    frappe.response['email'] = user.email"
+    },
+    {
+      "code": "Respuesta PDF (`type: 'pdf'`)",
+      "description": "Para enviar un archivo PDF generado. Debes proporcionar el contenido del archivo PDF.",
+      "example": "@frappe.whitelist()\ndef get_invoice_pdf(invoice_id):\n    pdf_content = get_pdf_from_html(...)\n    frappe.response.type = 'pdf'\n    frappe.response.filename = f'{invoice_id}.pdf'\n    frappe.response.filecontent = pdf_content"
+    },
+    {
+      "code": "Redirección (`type: 'redirect'`)",
+      "description": "Para realizar una redirección del lado del servidor, establece el tipo a 'redirect' y proporciona la ubicación de destino.",
+      "example": "@frappe.whitelist()\ndef old_url_handler():\n    frappe.response.type = 'redirect'\n    frappe.response.location = '/nueva-pagina'"
+    },
+    {
+      "code": "Texto Plano (`type: 'txt'`)",
+      "description": "Para enviar una respuesta de texto plano sin formato.",
+      "example": "@frappe.whitelist()\ndef get_raw_log():\n    # Este es un ejemplo simplificado\n    frappe.response.type = 'txt'\n    frappe.response.data = 'LOG: Sistema iniciado correctamente.'"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/rest-api-py-en.json
+++ b/data/cheatsheets/rest-api-py-en.json
@@ -1,0 +1,54 @@
+{
+  "title": "REST API (Python Backend)",
+  "language": "en",
+  "tags": ["python", "rest", "api", "http", "backend"],
+  "items": [
+    {
+      "code": "Authentication: Token",
+      "description": "Authenticate by passing a token in the Authorization header. The token is `api_key:api_secret` for a specific user.",
+      "example": "headers = {\n    'Authorization': 'token my_api_key:my_api_secret'\n}"
+    },
+    {
+      "code": "Authentication: Password",
+      "description": "Authenticate by making a POST request to `/api/method/login` with user credentials. Subsequent requests will use the session cookie.",
+      "example": "body = {\n    'usr': 'test@example.com',\n    'pwd': 'password123'\n}\n# POST to /api/method/login"
+    },
+    {
+      "code": "List Documents: GET /api/resource/:doctype",
+      "description": "Fetches a paginated list of documents. Supports filtering, sorting, and field selection.",
+      "example": "# Get open tasks, fetch subject and priority, order by creation date\nGET /api/resource/Task?fields=[\"subject\",\"priority\"]&filters=[[\"status\",\"=\",\"Open\"]]&order_by=creation%20desc"
+    },
+    {
+      "code": "Create Document: POST /api/resource/:doctype",
+      "description": "Creates a new document. The request body should be a JSON object representing the document.",
+      "example": "# Request Body for POST /api/resource/ToDo\n{\n    \"description\": \"My new ToDo from REST API\"\n}"
+    },
+    {
+      "code": "Read Document: GET /api/resource/:doctype/:name",
+      "description": "Fetches a single document by its unique name.",
+      "example": "GET /api/resource/ToDo/bf2e760e13"
+    },
+    {
+      "code": "Update Document: PUT /api/resource/:doctype/:name",
+      "description": "Updates one or more fields in an existing document. The request body should be a JSON object with the fields to update.",
+      "example": "# Request Body for PUT /api/resource/ToDo/bf2e760e13\n{\n    \"status\": \"Closed\",\n    \"description\": \"This task is now complete.\"\n}"
+    },
+    {
+      "code": "Delete Document: DELETE /api/resource/:doctype/:name",
+      "description": "Deletes a document by its unique name.",
+      "example": "DELETE /api/resource/ToDo/bf2e760e13"
+    },
+    {
+      "code": "Remote Method Call: /api/method/:dotted.path",
+      "description": "Executes any whitelisted Python method on the server. Use GET for read-only methods and POST for methods that modify data.",
+      "example": "# Get the currently logged-in user\nGET /api/method/frappe.auth.get_logged_user\n\n# Call a custom method with arguments\nPOST /api/method/my_app.utils.process_data\nBody: {\"customer_id\": \"CUST-001\"}"
+    },
+    {
+      "code": "File Upload: POST /api/method/upload_file",
+      "description": "Uploads a binary file. The request must be sent as `multipart/form-data` with the file attached.",
+      "example": "curl -X POST \\\n  http://<base-url>/api/method/upload_file \\\n  -H 'Authorization: token key:secret' \\\n  -F file=@/path/to/my_file.png"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/rest-api-py.json
+++ b/data/cheatsheets/rest-api-py.json
@@ -1,0 +1,54 @@
+{
+  "title": "API REST (Backend de Python)",
+  "language": "es",
+  "tags": ["python", "rest", "api", "http", "backend"],
+  "items": [
+    {
+      "code": "Autenticación: Token",
+      "description": "Autenticar pasando un token en la cabecera de Autorización. El token es `api_key:api_secret` para un usuario específico.",
+      "example": "headers = {\n    'Authorization': 'token mi_api_key:mi_api_secret'\n}"
+    },
+    {
+      "code": "Autenticación: Contraseña",
+      "description": "Autenticar haciendo una solicitud POST a `/api/method/login` con las credenciales del usuario. Las solicitudes posteriores usarán la cookie de sesión.",
+      "example": "body = {\n    'usr': 'test@example.com',\n    'pwd': 'password123'\n}\n# POST a /api/method/login"
+    },
+    {
+      "code": "Listar Documentos: GET /api/resource/:doctype",
+      "description": "Obtiene una lista paginada de documentos. Admite filtrado, ordenación y selección de campos.",
+      "example": "# Obtener tareas abiertas, traer asunto y prioridad, ordenar por fecha de creación\nGET /api/resource/Task?fields=[\"subject\",\"priority\"]&filters=[[\"status\",\"=\",\"Open\"]]&order_by=creation%20desc"
+    },
+    {
+      "code": "Crear Documento: POST /api/resource/:doctype",
+      "description": "Crea un nuevo documento. El cuerpo de la solicitud debe ser un objeto JSON que represente el documento.",
+      "example": "# Cuerpo de la solicitud para POST /api/resource/ToDo\n{\n    \"description\": \"Mi nuevo ToDo desde la API REST\"\n}"
+    },
+    {
+      "code": "Leer Documento: GET /api/resource/:doctype/:name",
+      "description": "Obtiene un único documento por su nombre único.",
+      "example": "GET /api/resource/ToDo/bf2e760e13"
+    },
+    {
+      "code": "Actualizar Documento: PUT /api/resource/:doctype/:name",
+      "description": "Actualiza uno o más campos en un documento existente. El cuerpo de la solicitud debe ser un objeto JSON con los campos a actualizar.",
+      "example": "# Cuerpo de la solicitud para PUT /api/resource/ToDo/bf2e760e13\n{\n    \"status\": \"Closed\",\n    \"description\": \"Esta tarea ya está completa.\"\n}"
+    },
+    {
+      "code": "Eliminar Documento: DELETE /api/resource/:doctype/:name",
+      "description": "Elimina un documento por su nombre único.",
+      "example": "DELETE /api/resource/ToDo/bf2e760e13"
+    },
+    {
+      "code": "Llamada a Método Remoto: /api/method/:ruta.punteada",
+      "description": "Ejecuta cualquier método de Python en la lista blanca del servidor. Usa GET para métodos de solo lectura y POST para métodos que modifican datos.",
+      "example": "# Obtener el usuario actualmente autenticado\nGET /api/method/frappe.auth.get_logged_user\n\n# Llamar a un método personalizado con argumentos\nPOST /api/method/my_app.utils.process_data\nCuerpo: {\"customer_id\": \"CUST-001\"}"
+    },
+    {
+      "code": "Subida de Archivo: POST /api/method/upload_file",
+      "description": "Sube un archivo binario. La solicitud debe enviarse como `multipart/form-data` con el archivo adjunto.",
+      "example": "curl -X POST \\\n  http://<base-url>/api/method/upload_file \\\n  -H 'Authorization: token key:secret' \\\n  -F file=@/ruta/a/mi_archivo.png"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/scanner-api-en.json
+++ b/data/cheatsheets/scanner-api-en.json
@@ -1,0 +1,24 @@
+{
+  "title": "Scanner API",
+  "language": "en",
+  "tags": ["javascript", "scanner", "barcode", "qrcode", "api"],
+  "items": [
+    {
+      "code": "new frappe.ui.Scanner({ ... })",
+      "description": "Creates a new Scanner instance to read barcodes, QR codes, etc., using the device's camera. It uses the Html5-QRCode library.",
+      "example": "// This code scans a single barcode and logs it to the console.\nnew frappe.ui.Scanner({\n    dialog: true,       // open camera scanner in a dialog\n    multiple: false,    // stop after scanning one value\n    on_scan(data) {\n        console.log(data.decodedText);\n    }\n});"
+    },
+    {
+      "code": "Continuous Scanning",
+      "description": "To continuously scan multiple codes, set the `multiple` option to `true`. You can then handle each scanned code in the `on_scan` callback.",
+      "example": "const scanner = new frappe.ui.Scanner({\n    dialog: true,\n    multiple: true,\n    on_scan(data) {\n        handle_scanned_barcode(data.decodedText);\n    }\n});"
+    },
+    {
+      "code": "scanner.stop_scan()",
+      "description": "If you have an instance of the scanner, you can programmatically stop the scanning process by calling this method.",
+      "example": "// Assuming 'scanner' is an instance from the previous example\nscanner.stop_scan();"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/scanner-api.json
+++ b/data/cheatsheets/scanner-api.json
@@ -1,0 +1,24 @@
+{
+  "title": "API de Escáner",
+  "language": "es",
+  "tags": ["javascript", "escaner", "codigo de barras", "codigo qr", "api"],
+  "items": [
+    {
+      "code": "new frappe.ui.Scanner({ ... })",
+      "description": "Crea una nueva instancia de Escáner para leer códigos de barras, códigos QR, etc., utilizando la cámara del dispositivo. Utiliza la biblioteca Html5-QRCode.",
+      "example": "// Este código escanea un solo código de barras y lo muestra en la consola.\nnew frappe.ui.Scanner({\n    dialog: true,       // abrir el escáner de la cámara en un diálogo\n    multiple: false,    // detenerse después de escanear un valor\n    on_scan(data) {\n        console.log(data.decodedText);\n    }\n});"
+    },
+    {
+      "code": "Escaneo Continuo",
+      "description": "Para escanear múltiples códigos de forma continua, establece la opción `multiple` en `true`. Luego puedes manejar cada código escaneado en el callback `on_scan`.",
+      "example": "const scanner = new frappe.ui.Scanner({\n    dialog: true,\n    multiple: true,\n    on_scan(data) {\n        handle_scanned_barcode(data.decodedText);\n    }\n});"
+    },
+    {
+      "code": "scanner.stop_scan()",
+      "description": "Si tienes una instancia del escáner, puedes detener el proceso de escaneo programáticamente llamando a este método.",
+      "example": "// Suponiendo que 'scanner' es una instancia del ejemplo anterior\nscanner.stop_scan();"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/search-py-en.json
+++ b/data/cheatsheets/search-py-en.json
@@ -1,0 +1,39 @@
+{
+  "title": "Custom Search Indexing (Python)",
+  "language": "en",
+  "tags": ["python", "search", "whoosh", "backend", "indexing"],
+  "items": [
+    {
+      "code": "class MySearch(FullTextSearch): ...",
+      "description": "To create a custom search index, you extend the `frappe.search.FullTextSearch` class and override its methods to define what data to index and how to index it.",
+      "example": "from frappe.search import FullTextSearch\n\nclass BlogSearch(FullTextSearch):\n    # Override methods here\n    pass"
+    },
+    {
+      "code": "def get_schema(self):",
+      "description": "Defines the structure (schema) of the search index using Whoosh fields like `ID` and `TEXT`. This determines what fields are stored and indexed for each document.",
+      "example": "from whoosh.fields import Schema, ID, TEXT\n\ndef get_schema(self):\n    return Schema(name=ID(stored=True), content=TEXT(stored=True))"
+    },
+    {
+      "code": "def get_items_to_index(self):",
+      "description": "Returns a list of all items that should be indexed. This method is responsible for querying the database or other sources to get the initial list of documents.",
+      "example": "def get_items_to_index(self):\n    # Return a list of all published blog post names\n    return frappe.get_all('Blog Post', filters={'published': 1}, pluck='name')"
+    },
+    {
+      "code": "def get_document_to_index(self, name):",
+      "description": "Takes a single item name (from the list returned by `get_items_to_index`) and returns a dictionary representing the document to be indexed. The keys must match the schema.",
+      "example": "def get_document_to_index(self, name):\n    blog = frappe.get_doc('Blog Post', name)\n    return frappe._dict(name=name, content=blog.content)"
+    },
+    {
+      "code": "def parse_result(self, result):",
+      "description": "Formats a single search result before it is returned to the user. `result` is a dictionary-like object from Whoosh.",
+      "example": "def parse_result(self, result):\n    # Return just the name of the blog post from the search result\n    return result['name']"
+    },
+    {
+      "code": "Instantiate and Build",
+      "description": "Once the class is defined, you can instantiate it and use its methods to build the index or perform searches.",
+      "example": "blog_search = BlogSearch('blog_index') # 'blog_index' is the name of the index file\n\n# To build the index for the first time\nblog_search.build()\n\n# To search the index\nresults = blog_search.search('some query text')"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/search-py.json
+++ b/data/cheatsheets/search-py.json
@@ -1,0 +1,39 @@
+{
+  "title": "Indexación de Búsqueda Personalizada (Python)",
+  "language": "es",
+  "tags": ["python", "busqueda", "whoosh", "backend", "indexación"],
+  "items": [
+    {
+      "code": "class MiBusqueda(FullTextSearch): ...",
+      "description": "Para crear un índice de búsqueda personalizado, extiendes la clase `frappe.search.FullTextSearch` y anulas sus métodos para definir qué datos indexar y cómo indexarlos.",
+      "example": "from frappe.search import FullTextSearch\n\nclass BlogSearch(FullTextSearch):\n    # Anular métodos aquí\n    pass"
+    },
+    {
+      "code": "def get_schema(self):",
+      "description": "Define la estructura (esquema) del índice de búsqueda utilizando campos de Whoosh como `ID` y `TEXT`. Esto determina qué campos se almacenan e indexan para cada documento.",
+      "example": "from whoosh.fields import Schema, ID, TEXT\n\ndef get_schema(self):\n    return Schema(name=ID(stored=True), content=TEXT(stored=True))"
+    },
+    {
+      "code": "def get_items_to_index(self):",
+      "description": "Devuelve una lista de todos los elementos que deben ser indexados. Este método es responsable de consultar la base de datos u otras fuentes para obtener la lista inicial de documentos.",
+      "example": "def get_items_to_index(self):\n    # Devolver una lista de todos los nombres de las publicaciones de blog publicadas\n    return frappe.get_all('Blog Post', filters={'published': 1}, pluck='name')"
+    },
+    {
+      "code": "def get_document_to_index(self, name):",
+      "description": "Toma el nombre de un solo elemento (de la lista devuelta por `get_items_to_index`) y devuelve un diccionario que representa el documento a indexar. Las claves deben coincidir con el esquema.",
+      "example": "def get_document_to_index(self, name):\n    blog = frappe.get_doc('Blog Post', name)\n    return frappe._dict(name=name, content=blog.content)"
+    },
+    {
+      "code": "def parse_result(self, result):",
+      "description": "Formatea un único resultado de búsqueda antes de devolverlo al usuario. `result` es un objeto similar a un diccionario de Whoosh.",
+      "example": "def parse_result(self, result):\n    # Devolver solo el nombre de la publicación del blog del resultado de la búsqueda\n    return result['name']"
+    },
+    {
+      "code": "Instanciar y Construir",
+      "description": "Una vez definida la clase, puedes instanciarla y usar sus métodos para construir el índice o realizar búsquedas.",
+      "example": "blog_search = BlogSearch('blog_index') # 'blog_index' es el nombre del archivo de índice\n\n# Para construir el índice por primera vez\nblog_search.build()\n\n# Para buscar en el índice\nresults = blog_search.search('algún texto de consulta')"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/server-calls-en.json
+++ b/data/cheatsheets/server-calls-en.json
@@ -1,0 +1,59 @@
+{
+  "title": "Server Calls (AJAX)",
+  "language": "en",
+  "tags": ["javascript", "ajax", "database", "api"],
+  "items": [
+    {
+      "code": "frappe.call(method, args)",
+      "description": "Makes an AJAX request to a whitelisted Python method on the server and returns its response.",
+      "example": "// Simple call\nfrappe.call('ping').then(r => console.log(r.message)); // 'pong'\n\n// Call with arguments and options\nfrappe.call({\n    method: 'frappe.core.doctype.user.user.get_role_profile',\n    args: {\n        role_profile: 'Test'\n    },\n    freeze: true,\n    callback: (r) => {\n        console.log(r.message);\n    }\n});"
+    },
+    {
+      "code": "frappe.db.get_doc(doctype, name, filters)",
+      "description": "Returns the full Document object for a given doctype and name, or the first one matching filters.",
+      "example": "// Get doc by name\nfrappe.db.get_doc('Task', 'TASK00002').then(doc => console.log(doc));\n\n// Get doc by filters\nfrappe.db.get_doc('Task', null, { status: 'Open' }).then(doc => console.log(doc));"
+    },
+    {
+      "code": "frappe.db.get_list(doctype, { fields, filters })",
+      "description": "Returns a list of records from a doctype, specifying which fields to fetch and applying filters.",
+      "example": "frappe.db.get_list('Task', {\n    fields: ['subject', 'description'],\n    filters: {\n        status: 'Open'\n    }\n}).then(records => {\n    console.log(records);\n});"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name | filters, fieldname | [fieldnames])",
+      "description": "Returns one or more field values for a specific document or a document matching filters.",
+      "example": "// Get a single value\nfrappe.db.get_value('Task', 'TASK00004', 'status').then(r => console.log(r.message.status));\n\n// Get multiple values\nfrappe.db.get_value('Task', 'TASK00004', ['status', 'subject']).then(r => console.log(r.message));"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, field)",
+      "description": "Returns a field value from a Single DocType.",
+      "example": "frappe.db.get_single_value('System Settings', 'time_zone').then(tz => console.log(tz));"
+    },
+    {
+      "code": "frappe.db.set_value(doctype, docname, fieldname | {fieldname: value}, value)",
+      "description": "Sets one or more field values for a document on the server.",
+      "example": "// Set a single value\nfrappe.db.set_value('Task', 'TASK00004', 'status', 'Open').then(r => console.log(r.message));\n\n// Set multiple values\nfrappe.db.set_value('Task', 'TASK00004', { status: 'Working', priority: 'Medium' }).then(r => console.log(r.message));"
+    },
+    {
+      "code": "frappe.db.insert(doc)",
+      "description": "Inserts a new document into the database.",
+      "example": "frappe.db.insert({\n    doctype: 'Task',\n    subject: 'New Task from DB API'\n}).then(doc => {\n    console.log(doc);\n});"
+    },
+    {
+      "code": "frappe.db.count(doctype, filters)",
+      "description": "Returns the number of records for a given doctype, with optional filters.",
+      "example": "// Count all tasks\nfrappe.db.count('Task').then(count => console.log(count));\n\n// Count open tasks\nfrappe.db.count('Task', { status: 'Open' }).then(count => console.log(count));"
+    },
+    {
+      "code": "frappe.db.delete_doc(doctype, name)",
+      "description": "Deletes a document from the database.",
+      "example": "frappe.db.delete_doc('Task', 'TASK00004');"
+    },
+    {
+      "code": "frappe.db.exists(doctype, name)",
+      "description": "Returns a boolean indicating if a document exists.",
+      "example": "frappe.db.exists('Task', 'TASK00004').then(exists => console.log(exists));"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/server-calls.json
+++ b/data/cheatsheets/server-calls.json
@@ -1,0 +1,59 @@
+{
+  "title": "Llamadas al Servidor (AJAX)",
+  "language": "es",
+  "tags": ["javascript", "ajax", "base de datos", "api"],
+  "items": [
+    {
+      "code": "frappe.call(method, args)",
+      "description": "Realiza una solicitud AJAX a un método de Python en la lista blanca del servidor y devuelve su respuesta.",
+      "example": "// Llamada simple\nfrappe.call('ping').then(r => console.log(r.message)); // 'pong'\n\n// Llamada con argumentos y opciones\nfrappe.call({\n    method: 'frappe.core.doctype.user.user.get_role_profile',\n    args: {\n        role_profile: 'Test'\n    },\n    freeze: true,\n    callback: (r) => {\n        console.log(r.message);\n    }\n});"
+    },
+    {
+      "code": "frappe.db.get_doc(doctype, name, filters)",
+      "description": "Devuelve el objeto Documento completo para un doctype y nombre dados, o el primero que coincida con los filtros.",
+      "example": "// Obtener documento por nombre\nfrappe.db.get_doc('Task', 'TASK00002').then(doc => console.log(doc));\n\n// Obtener documento por filtros\nfrappe.db.get_doc('Task', null, { status: 'Open' }).then(doc => console.log(doc));"
+    },
+    {
+      "code": "frappe.db.get_list(doctype, { fields, filters })",
+      "description": "Devuelve una lista de registros de un doctype, especificando qué campos obtener y aplicando filtros.",
+      "example": "frappe.db.get_list('Task', {\n    fields: ['subject', 'description'],\n    filters: {\n        status: 'Open'\n    }\n}).then(records => {\n    console.log(records);\n});"
+    },
+    {
+      "code": "frappe.db.get_value(doctype, name | filters, fieldname | [fieldnames])",
+      "description": "Devuelve uno o más valores de campo para un documento específico o un documento que coincida con los filtros.",
+      "example": "// Obtener un solo valor\nfrappe.db.get_value('Task', 'TASK00004', 'status').then(r => console.log(r.message.status));\n\n// Obtener múltiples valores\nfrappe.db.get_value('Task', 'TASK00004', ['status', 'subject']).then(r => console.log(r.message));"
+    },
+    {
+      "code": "frappe.db.get_single_value(doctype, field)",
+      "description": "Devuelve el valor de un campo de un DocType Single.",
+      "example": "frappe.db.get_single_value('System Settings', 'time_zone').then(tz => console.log(tz));"
+    },
+    {
+      "code": "frappe.db.set_value(doctype, docname, fieldname | {fieldname: value}, value)",
+      "description": "Establece uno o más valores de campo para un documento en el servidor.",
+      "example": "// Establecer un solo valor\nfrappe.db.set_value('Task', 'TASK00004', 'status', 'Open').then(r => console.log(r.message));\n\n// Establecer múltiples valores\nfrappe.db.set_value('Task', 'TASK00004', { status: 'Working', priority: 'Medium' }).then(r => console.log(r.message));"
+    },
+    {
+      "code": "frappe.db.insert(doc)",
+      "description": "Inserta un nuevo documento en la base de datos.",
+      "example": "frappe.db.insert({\n    doctype: 'Task',\n    subject: 'Nueva Tarea desde DB API'\n}).then(doc => {\n    console.log(doc);\n});"
+    },
+    {
+      "code": "frappe.db.count(doctype, filters)",
+      "description": "Devuelve el número de registros para un doctype dado, con filtros opcionales.",
+      "example": "// Contar todas las tareas\nfrappe.db.count('Task').then(count => console.log(count));\n\n// Contar tareas abiertas\nfrappe.db.count('Task', { status: 'Open' }).then(count => console.log(count));"
+    },
+    {
+      "code": "frappe.db.delete_doc(doctype, name)",
+      "description": "Elimina un documento de la base de datos.",
+      "example": "frappe.db.delete_doc('Task', 'TASK00004');"
+    },
+    {
+      "code": "frappe.db.exists(doctype, name)",
+      "description": "Devuelve un booleano que indica si un documento existe.",
+      "example": "frappe.db.exists('Task', 'TASK00004').then(exists => console.log(exists));"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/tree-view-en.json
+++ b/data/cheatsheets/tree-view-en.json
@@ -1,0 +1,64 @@
+{
+  "title": "Tree View Settings",
+  "language": "en",
+  "tags": ["javascript", "tree-view", "api"],
+  "items": [
+    {
+      "code": "frappe.treeview_settings['DocType'] = { ... }",
+      "description": "To customize the Tree View for a DocType, create a `{doctype}_tree.js` file and define the settings within this structure.",
+      "example": "frappe.treeview_settings['Account'] = {\n    // tree view settings go here\n};"
+    },
+    {
+      "code": "breadcrumb: 'Accounting'",
+      "description": "Sets the breadcrumb navigation path displayed at the top of the page.",
+      "example": "breadcrumb: 'Accounting'"
+    },
+    {
+      "code": "title: 'Chart of Accounts'",
+      "description": "Sets the main title for the Tree View page.",
+      "example": "title: 'Chart of Accounts'"
+    },
+    {
+      "code": "filters: [ { ... } ]",
+      "description": "An array of objects defining filter fields to be displayed at the top of the tree view.",
+      "example": "filters: [\n    {\n        fieldname: 'company',\n        fieldtype:'Select',\n        options: 'Company 1\\nCompany 2',\n        label: 'Company'\n    }\n]"
+    },
+    {
+      "code": "get_tree_nodes: 'path.to.method'",
+      "description": "The dotted path to a whitelisted Python method that fetches the child nodes for a given parent node.",
+      "example": "get_tree_nodes: 'my_app.utils.get_children'"
+    },
+    {
+      "code": "add_tree_node: 'path.to.method'",
+      "description": "The dotted path to a whitelisted Python method that handles the creation of a new node.",
+      "example": "add_tree_node: 'my_app.utils.add_node'"
+    },
+    {
+      "code": "fields: [ { ... } ]",
+      "description": "An array of field definitions for the dialog that appears when adding a new node.",
+      "example": "fields: [\n    {\n        fieldtype: 'Data', fieldname: 'account_name',\n        label: 'New Account Name', reqd: true\n    },\n    {\n        fieldtype: 'Check', fieldname: 'is_group', label: 'Is Group'\n    }\n]"
+    },
+    {
+      "code": "menu_items: [ { ... } ]",
+      "description": "Adds custom items to the 'Menu' (three-dot) dropdown in the page header.",
+      "example": "menu_items: [\n    {\n        label: 'New Company',\n        action: function() { frappe.new_doc('Company', true) },\n        condition: 'frappe.boot.user.can_create.indexOf(\"Company\") !== -1'\n    }\n]"
+    },
+    {
+      "code": "toolbar: [ { ... } ]",
+      "description": "Adds custom buttons next to each node in the tree. Requires `extend_toolbar: true`.",
+      "example": "extend_toolbar: true,\ntoolbar: [\n    {\n        label: 'Add Child',\n        condition: function(node) { return node.is_group; },\n        click: function(node) { /* ... */ },\n        btnClass: 'hidden-xs'\n    }\n]"
+    },
+    {
+      "code": "onload: function(treeview) { ... }",
+      "description": "A function that is triggered once when the tree view is first instantiated.",
+      "example": "onload: function(treeview) {\n    console.log('Tree view loaded');\n}"
+    },
+    {
+      "code": "onrender: function(node) { ... }",
+      "description": "A function that is triggered every time a node is rendered in the tree.",
+      "example": "onrender: function(node) {\n    if(node.data.is_group) {\n        $(node.parent).find('.tree-label').css('font-weight', 'bold');\n    }\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/tree-view.json
+++ b/data/cheatsheets/tree-view.json
@@ -1,0 +1,64 @@
+{
+  "title": "Configuración de Vista de Árbol",
+  "language": "es",
+  "tags": ["javascript", "vista-de-arbol", "api"],
+  "items": [
+    {
+      "code": "frappe.treeview_settings['DocType'] = { ... }",
+      "description": "Para personalizar la Vista de Árbol para un DocType, crea un archivo `{doctype}_tree.js` y define la configuración dentro de esta estructura.",
+      "example": "frappe.treeview_settings['Account'] = {\n    // la configuración de la vista de árbol va aquí\n};"
+    },
+    {
+      "code": "breadcrumb: 'Contabilidad'",
+      "description": "Establece la ruta de navegación (breadcrumb) que se muestra en la parte superior de la página.",
+      "example": "breadcrumb: 'Contabilidad'"
+    },
+    {
+      "code": "title: 'Plan de Cuentas'",
+      "description": "Establece el título principal para la página de la Vista de Árbol.",
+      "example": "title: 'Plan de Cuentas'"
+    },
+    {
+      "code": "filters: [ { ... } ]",
+      "description": "Un array de objetos que definen campos de filtro que se mostrarán en la parte superior de la vista de árbol.",
+      "example": "filters: [\n    {\n        fieldname: 'company',\n        fieldtype:'Select',\n        options: 'Compañía 1\\nCompañía 2',\n        label: 'Compañía'\n    }\n]"
+    },
+    {
+      "code": "get_tree_nodes: 'ruta.a.metodo'",
+      "description": "La ruta punteada a un método de Python en la lista blanca que obtiene los nodos hijos para un nodo padre dado.",
+      "example": "get_tree_nodes: 'mi_app.utilidades.get_children'"
+    },
+    {
+      "code": "add_tree_node: 'ruta.a.metodo'",
+      "description": "La ruta punteada a un método de Python en la lista blanca que maneja la creación de un nuevo nodo.",
+      "example": "add_tree_node: 'mi_app.utilidades.add_node'"
+    },
+    {
+      "code": "fields: [ { ... } ]",
+      "description": "Un array de definiciones de campos para el diálogo que aparece al agregar un nuevo nodo.",
+      "example": "fields: [\n    {\n        fieldtype: 'Data', fieldname: 'account_name',\n        label: 'Nuevo Nombre de Cuenta', reqd: true\n    },\n    {\n        fieldtype: 'Check', fieldname: 'is_group', label: 'Es Grupo'\n    }\n]"
+    },
+    {
+      "code": "menu_items: [ { ... } ]",
+      "description": "Agrega elementos personalizados al menú desplegable 'Menú' (tres puntos) en el encabezado de la página.",
+      "example": "menu_items: [\n    {\n        label: 'Nueva Compañía',\n        action: function() { frappe.new_doc('Company', true) },\n        condition: 'frappe.boot.user.can_create.indexOf(\"Company\") !== -1'\n    }\n]"
+    },
+    {
+      "code": "toolbar: [ { ... } ]",
+      "description": "Agrega botones personalizados junto a cada nodo en el árbol. Requiere `extend_toolbar: true`.",
+      "example": "extend_toolbar: true,\ntoolbar: [\n    {\n        label: 'Añadir Hijo',\n        condition: function(node) { return node.is_group; },\n        click: function(node) { /* ... */ },\n        btnClass: 'hidden-xs'\n    }\n]"
+    },
+    {
+      "code": "onload: function(treeview) { ... }",
+      "description": "Una función que se dispara una vez cuando la vista de árbol se instancia por primera vez.",
+      "example": "onload: function(treeview) {\n    console.log('Vista de árbol cargada');\n}"
+    },
+    {
+      "code": "onrender: function(node) { ... }",
+      "description": "Una función que se dispara cada vez que un nodo se renderiza en el árbol.",
+      "example": "onrender: function(node) {\n    if(node.data.is_group) {\n        $(node.parent).find('.tree-label').css('font-weight', 'bold');\n    }\n}"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/utils-py-en.json
+++ b/data/cheatsheets/utils-py-en.json
@@ -1,0 +1,44 @@
+{
+  "title": "Utility Functions (Python)",
+  "language": "en",
+  "tags": ["python", "utils", "helpers", "backend"],
+  "items": [
+    {
+      "code": "Date & Time Utilities",
+      "description": "Functions for working with dates and times.",
+      "example": "from frappe.utils import now, today, getdate, add_to_date, pretty_date\n\n# Current datetime string: '2023-10-26 12:30:00'\nnow_str = now()\n\n# Current date string: '2023-10-26'\ntoday_str = today()\n\n# Date object from string\ndate_obj = getdate('2023-10-26')\n\n# Add 10 days to the current date\nfuture_date = add_to_date(None, days=10, as_string=True)\n\n# Human-readable time ago: '2 hours ago'\nfriendly_date = pretty_date('2023-10-26 10:30:00')"
+    },
+    {
+      "code": "Formatting Utilities",
+      "description": "Functions for formatting data into user-friendly strings.",
+      "example": "from frappe.utils import comma_and, money_in_words, get_abbr\n\n# 'Apple, Banana and Orange'\nformatted_list = comma_and(['Apple', 'Banana', 'Orange'], add_quotes=False)\n\n# 'USD One Hundred and Fifty Cents only.'\nin_words = money_in_words(100.50, 'USD', 'Cents')\n\n# 'ERP'\ninitials = get_abbr('Enterprise Resource Planning', max_len=3)"
+    },
+    {
+      "code": "Validation Utilities",
+      "description": "Functions to validate common data types like emails, URLs, and phone numbers.",
+      "example": "from frappe.utils import validate_email_address, validate_url, validate_phone_number\n\n# Returns 'test@example.com' or raises an exception\nvalid_email = validate_email_address('test@example.com', throw=True)\n\n# Returns True\nis_valid_url = validate_url('https://frappe.io')\n\n# Returns True\nis_valid_phone = validate_phone_number('+1-555-123-4567')"
+    },
+    {
+      "code": "frappe.sendmail(...)",
+      "description": "Sends an email. Can use Jinja templates and include attachments.",
+      "example": "frappe.sendmail(\n    recipients=['test@example.com'],\n    subject='Welcome to our App',\n    template='welcome_email_template',\n    args={'user_name': 'John Doe'},\n    attachments=[{'file_url': '/files/welcome_guide.pdf'}]\n)"
+    },
+    {
+      "code": "frappe.cache()",
+      "description": "Returns a Redis cache instance for storing and retrieving key-value pairs.",
+      "example": "cache = frappe.cache()\n\n# Set a value in the cache\ncache.set('my_key', 'my_value')\n\n# Get a value from the cache\nretrieved_value = cache.get('my_key') # returns bytes: b'my_value'"
+    },
+    {
+      "code": "get_pdf(html)",
+      "description": "Converts an HTML string into a PDF file, returning the raw PDF data as bytes.",
+      "example": "from frappe.utils.pdf import get_pdf\n\nhtml_content = '<h1>Hello, PDF!</h1>'\npdf_data = get_pdf(html_content)\n\n# Can be used to attach to emails or in a download response"
+    },
+    {
+      "code": "random_string(length)",
+      "description": "Generates a random alphanumeric string of a specified length.",
+      "example": "from frappe.utils import random_string\n\n# Generate a 16-character random token\napi_token = random_string(16)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}

--- a/data/cheatsheets/utils-py.json
+++ b/data/cheatsheets/utils-py.json
@@ -1,0 +1,44 @@
+{
+  "title": "Funciones de Utilidad (Python)",
+  "language": "es",
+  "tags": ["python", "utils", "helpers", "backend"],
+  "items": [
+    {
+      "code": "Utilidades de Fecha y Hora",
+      "description": "Funciones para trabajar con fechas y horas.",
+      "example": "from frappe.utils import now, today, getdate, add_to_date, pretty_date\n\n# Cadena de fecha y hora actual: '2023-10-26 12:30:00'\nnow_str = now()\n\n# Cadena de fecha actual: '2023-10-26'\ntoday_str = today()\n\n# Objeto de fecha desde cadena\ndate_obj = getdate('2023-10-26')\n\n# Añadir 10 días a la fecha actual\nfuture_date = add_to_date(None, days=10, as_string=True)\n\n# Tiempo transcurrido legible: 'hace 2 horas'\nfriendly_date = pretty_date('2023-10-26 10:30:00')"
+    },
+    {
+      "code": "Utilidades de Formateo",
+      "description": "Funciones para formatear datos en cadenas amigables para el usuario.",
+      "example": "from frappe.utils import comma_and, money_in_words, get_abbr\n\n# 'Manzana, Banana y Naranja'\nformatted_list = comma_and(['Manzana', 'Banana', 'Naranja'], add_quotes=False)\n\n# 'USD Cien y Cincuenta Centavos solamente.'\nin_words = money_in_words(100.50, 'USD', 'Cents')\n\n# 'ERP'\ninitials = get_abbr('Enterprise Resource Planning', max_len=3)"
+    },
+    {
+      "code": "Utilidades de Validación",
+      "description": "Funciones para validar tipos de datos comunes como correos electrónicos, URLs y números de teléfono.",
+      "example": "from frappe.utils import validate_email_address, validate_url, validate_phone_number\n\n# Devuelve 'test@example.com' o lanza una excepción\nvalid_email = validate_email_address('test@example.com', throw=True)\n\n# Devuelve True\nis_valid_url = validate_url('https://frappe.io')\n\n# Devuelve True\nis_valid_phone = validate_phone_number('+1-555-123-4567')"
+    },
+    {
+      "code": "frappe.sendmail(...)",
+      "description": "Envía un correo electrónico. Puede usar plantillas Jinja e incluir archivos adjuntos.",
+      "example": "frappe.sendmail(\n    recipients=['test@example.com'],\n    subject='Bienvenido a nuestra App',\n    template='welcome_email_template',\n    args={'user_name': 'John Doe'},\n    attachments=[{'file_url': '/files/guia_bienvenida.pdf'}]\n)"
+    },
+    {
+      "code": "frappe.cache()",
+      "description": "Devuelve una instancia de caché de Redis para almacenar y recuperar pares clave-valor.",
+      "example": "cache = frappe.cache()\n\n# Establecer un valor en la caché\ncache.set('mi_clave', 'mi_valor')\n\n# Obtener un valor de la caché\nretrieved_value = cache.get('mi_clave') # devuelve bytes: b'mi_valor'"
+    },
+    {
+      "code": "get_pdf(html)",
+      "description": "Convierte una cadena HTML en un archivo PDF, devolviendo los datos brutos del PDF como bytes.",
+      "example": "from frappe.utils.pdf import get_pdf\n\nhtml_content = '<h1>¡Hola, PDF!</h1>'\npdf_data = get_pdf(html_content)\n\n# Se puede usar para adjuntar a correos o en una respuesta de descarga"
+    },
+    {
+      "code": "random_string(length)",
+      "description": "Genera una cadena alfanumérica aleatoria de una longitud especificada.",
+      "example": "from frappe.utils import random_string\n\n# Generar un token aleatorio de 16 caracteres\napi_token = random_string(16)"
+    }
+  ],
+  "created": "2024-01-01",
+  "updated": "2024-01-01"
+}


### PR DESCRIPTION
This commit introduces a comprehensive set of cheatsheets for various JavaScript and Python APIs within the Frappe framework.

- Created 54 new cheatsheet files in JSON format under `data/cheatsheets/`.
- Each cheatsheet is provided in both English and Spanish.
- The cheatsheets cover APIs for Database, Dialogs, Forms, REST, Query Builder, and more.
- Follows the existing format, including title, language, tags, and itemized code examples with descriptions.
- Adopted a `-py` suffix for Python-specific cheatsheet files to avoid naming conflicts with JavaScript counterparts.